### PR TITLE
matching required fields to inheritence

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -673,6 +673,7 @@ components:
         - type: object
           required:
             - receivedAmount
+            - type
           properties:
             type:
               $ref: '#/components/schemas/TransactionType'
@@ -688,6 +689,7 @@ components:
         - type: object
           required:
             - sentAmount
+            - type
           properties:
             type:
               $ref: '#/components/schemas/TransactionType'


### PR DESCRIPTION
Otherwise importing generated sdk gives a requirement mismatch.