### PR TITLE
[Umaaas-api]Add missing failure reasons in incoming transaction

### DIFF
--- a/codegen-config/python/config.yml
+++ b/codegen-config/python/config.yml
@@ -2,7 +2,7 @@ templateDir: codegen-config/python/templates
 additionalProperties:
   infoEmail: "info@lightspark.com"
   packageUrl: https://github.com/lightsparkdev/umaaas-api
-  packageVersion: 0.0.28
+  packageVersion: 0.0.29
 packageName: umaaas_api
 globalProperties:
   webhooks: "false"

--- a/generated/python/docs/IncomingTransactionFailureReason.md
+++ b/generated/python/docs/IncomingTransactionFailureReason.md
@@ -16,6 +16,10 @@ Reason for failure of an incoming transaction. This is used to provide more cont
 
 * `MISSING_MANDATORY_PAYEE_DATA` (value: `'MISSING_MANDATORY_PAYEE_DATA'`)
 
+* `QUOTE_EXPIRED` (value: `'QUOTE_EXPIRED'`)
+
+* `QUOTE_EXECUTION_FAILED` (value: `'QUOTE_EXECUTION_FAILED'`)
+
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 
 

--- a/generated/python/pyproject.toml
+++ b/generated/python/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "umaaas_api"
-version = "0.0.28"
+version = "0.0.29"
 description = "UMA as a Service (UMAaaS) API"
 authors = ["Lightspark Support <support@lightspark.com>"]
 license = "Proprietary"

--- a/generated/python/setup.cfg
+++ b/generated/python/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = umaaas-api
-version = 0.0.28
+version = 0.0.29
 description = API for managing global payments to and from UMA addresses.  This service facilitates cross-currency financial transactions using simple human-readable UMA addresses. 
 long_description = file: README.md
 long_description_content_type = text/markdown

--- a/generated/python/setup.py
+++ b/generated/python/setup.py
@@ -22,7 +22,7 @@ from setuptools import setup, find_packages  # noqa: H301
 # prerequisite: setuptools
 # http://pypi.python.org/pypi/setuptools
 NAME = "umaaas-api"
-VERSION = "0.0.28"
+VERSION = "0.0.29"
 PYTHON_REQUIRES = ">= 3.9"
 REQUIRES = [
     "urllib3 >= 2.1.0, < 3.0.0",

--- a/generated/python/umaaas_api/__init__.py
+++ b/generated/python/umaaas_api/__init__.py
@@ -15,7 +15,7 @@
 """  # noqa: E501
 
 
-__version__ = "0.0.28"
+__version__ = "0.0.29"
 
 # import apis into sdk package
 from umaaas_api.api.api_tokens_api import APITokensApi

--- a/generated/python/umaaas_api/api_client.py
+++ b/generated/python/umaaas_api/api_client.py
@@ -91,7 +91,7 @@ class ApiClient:
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'OpenAPI-Generator/0.0.28/python'
+        self.user_agent = 'OpenAPI-Generator/0.0.29/python'
         self.client_side_validation = configuration.client_side_validation
 
     def __enter__(self):

--- a/generated/python/umaaas_api/configuration.py
+++ b/generated/python/umaaas_api/configuration.py
@@ -556,7 +556,7 @@ conf = umaaas_api.Configuration(
                "OS: {env}\n"\
                "Python Version: {pyversion}\n"\
                "Version of the API: 2025-05-15\n"\
-               "SDK Package Version: 0.0.28".\
+               "SDK Package Version: 0.0.29".\
                format(env=sys.platform, pyversion=sys.version)
 
     def get_host_settings(self) -> List[HostSetting]:

--- a/generated/python/umaaas_api/models/incoming_transaction_failure_reason.py
+++ b/generated/python/umaaas_api/models/incoming_transaction_failure_reason.py
@@ -33,6 +33,8 @@ class IncomingTransactionFailureReason(str, Enum):
     PAYMENT_APPROVAL_TIMED_OUT = 'PAYMENT_APPROVAL_TIMED_OUT'
     OFFRAMP_FAILED = 'OFFRAMP_FAILED'
     MISSING_MANDATORY_PAYEE_DATA = 'MISSING_MANDATORY_PAYEE_DATA'
+    QUOTE_EXPIRED = 'QUOTE_EXPIRED'
+    QUOTE_EXECUTION_FAILED = 'QUOTE_EXECUTION_FAILED'
 
     @classmethod
     def from_json(cls, json_str: str) -> Self:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -604,7 +604,7 @@ components:
 
     IncomingTransactionFailureReason:
       type: string
-      enum: [LNURLP_FAILED, PAY_REQUEST_FAILED, PAYMENT_APPROVAL_WEBHOOK_ERROR, PAYMENT_APPROVAL_TIMED_OUT, OFFRAMP_FAILED, MISSING_MANDATORY_PAYEE_DATA]
+      enum: [LNURLP_FAILED, PAY_REQUEST_FAILED, PAYMENT_APPROVAL_WEBHOOK_ERROR, PAYMENT_APPROVAL_TIMED_OUT, OFFRAMP_FAILED, MISSING_MANDATORY_PAYEE_DATA, QUOTE_EXPIRED, QUOTE_EXECUTION_FAILED]
       description: >-
         Reason for failure of an incoming transaction. This is used to provide more context on why a transaction failed.
         If the transaction is not in a failed state, this field is omitted.


### PR DESCRIPTION
### TL;DR

Added two new failure reasons for incoming transactions: `QUOTE_EXPIRED` and `QUOTE_EXECUTION_FAILED` and bumped version.

### What changed?

- Added `QUOTE_EXPIRED` and `QUOTE_EXECUTION_FAILED` to the `IncomingTransactionFailureReason` enum in the OpenAPI specification
- Updated the generated Python documentation and model class to include these new enum values
- Bumped version from 0.0.28 to 0.0.29