### PR TITLE
finishing frontend

### DIFF
--- a/samples/kotlin/umaaas-quickstart/frontend/src/components/forms/PaymentInitiation.tsx
+++ b/samples/kotlin/umaaas-quickstart/frontend/src/components/forms/PaymentInitiation.tsx
@@ -74,7 +74,10 @@ export default function PaymentInitiation({ currUser, lookupResponse, onQuoteSuc
       // Convert amount to smallest unit based on the locked currency's decimal places
       const lockedCurrency = lastEditedField === 'receiving' ? receivingCurrency : 'USD';
       const amountString = lastEditedField === 'usd' ? usdAmount : receivingAmount;
-      const lockedCurrencyAmount = convertToSmallestUnit(amountString, lockedCurrency);
+      const decimals = lockedCurrency === 'USD' 
+        ? parseInt(import.meta.env.VITE_PUBLIC_CURRENCY_DECIMALS || '2', 10)
+        : lookupData.supportedCurrencies[0].currency.decimals;
+      const lockedCurrencyAmount = convertToSmallestUnit(amountString, decimals);
       
       const requestBody = {
         lockedCurrencyAmount,

--- a/samples/kotlin/umaaas-quickstart/frontend/src/lib/currency-utils.ts
+++ b/samples/kotlin/umaaas-quickstart/frontend/src/lib/currency-utils.ts
@@ -38,25 +38,22 @@ export const getCurrencyDecimals = (currencyCode: string): number => {
 /**
  * Convert a decimal amount to the smallest unit (integer) based on currency decimal places
  */
-export const convertToSmallestUnit = (amount: string, currencyCode: string): number => {
-  const decimals = getCurrencyDecimals(currencyCode);
-  const multiplier = Math.pow(10, decimals);
+export const convertToSmallestUnit = (amount: string, currencyDecimals: number): number => {
+  const multiplier = Math.pow(10, currencyDecimals);
   return Math.round(parseFloat(amount) * multiplier);
 };
 
 /**
  * Convert from smallest unit back to decimal amount
  */
-export const convertFromSmallestUnit = (amount: number, currencyCode: string): number => {
-  const decimals = getCurrencyDecimals(currencyCode);
-  const divisor = Math.pow(10, decimals);
+export const convertFromSmallestUnit = (amount: number, currencyDecimals: number): number => {
+  const divisor = Math.pow(10, currencyDecimals);
   return amount / divisor;
 };
 
 /**
  * Format currency amount with proper decimal places
  */
-export const formatCurrencyAmount = (amount: number, currencyCode: string): string => {
-  const decimals = getCurrencyDecimals(currencyCode);
-  return amount.toFixed(decimals);
+export const formatCurrencyAmount = (amount: number, currencyDecimals: number): string => {
+  return amount.toFixed(currencyDecimals);
 };


### PR DESCRIPTION
### TL;DR

Refactored currency utility functions to accept decimal places directly instead of currency codes.

### What changed?

- Modified currency utility functions (`convertToSmallestUnit`, `convertFromSmallestUnit`, and `formatCurrencyAmount`) to accept currency decimals as a parameter instead of currency codes
- Updated the `PaymentInitiation` component to determine the correct decimal places based on the currency type:
  - For USD, it now uses the value from environment variable `VITE_PUBLIC_CURRENCY_DECIMALS`
  - For other currencies, it uses the decimals from the `lookupData.supportedCurrencies` array

### How to test?

1. Test payment initiation with both USD and non-USD currencies
2. Verify that amounts are correctly converted between decimal and smallest unit representations
3. Confirm that currency formatting displays the correct number of decimal places

### Why make this change?

This change improves flexibility by allowing the currency utility functions to work with decimal places directly, rather than relying on hardcoded currency code mappings. It also enables proper handling of currencies with varying decimal places and makes the code more maintainable by centralizing the decimal place determination logic.