### PR TITLE
updating json serialzation to only serialize params with annotations

### DIFF
--- a/samples/kotlin/umaaas-quickstart/backend/src/main/kotlin/lib/JsonUtils.kt
+++ b/samples/kotlin/umaaas-quickstart/backend/src/main/kotlin/lib/JsonUtils.kt
@@ -1,6 +1,9 @@
 package com.lightspark.uma.umaaas.lib
 
+import com.fasterxml.jackson.annotation.JsonAutoDetect
 import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.PropertyAccessor
+import com.fasterxml.jackson.databind.MapperFeature
 import com.fasterxml.jackson.databind.SerializationFeature
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
@@ -11,7 +14,12 @@ object JsonUtils {
         .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
         .enable(SerializationFeature.INDENT_OUTPUT)
         .setSerializationInclusion(JsonInclude.Include.NON_NULL)
-    
+        .disable(
+            MapperFeature.AUTO_DETECT_FIELDS,
+            MapperFeature.AUTO_DETECT_GETTERS,
+            MapperFeature.AUTO_DETECT_IS_GETTERS,
+            MapperFeature.AUTO_DETECT_SETTERS
+        )
     fun prettyPrint(json: String): String {
         return try {
             val jsonNode = prettyMapper.readTree(json)


### PR DESCRIPTION
### TL;DR

Fixed webhook logging and JSON mapper configuration, with a minor typo in currency utils.

### What changed?

- Modified `JsonUtils.kt` to disable auto-detection of fields, getters, setters, and is-getters in the Jackson mapper
- Fixed webhook logging in `Webhooks.kt` to print the raw JSON body instead of the parsed object
- Introduced an unintended character 'Ø' in the `currency-utils.ts` file after the zero-decimal currencies array

### How to test?

1. Trigger a webhook to verify the raw JSON is properly logged
2. Verify JSON serialization/deserialization works correctly with the updated mapper configuration
3. Fix the typo in `currency-utils.ts` by removing the 'Ø' character after the array declaration

### Why make this change?

The changes to the JSON mapper configuration provide more explicit control over which properties are serialized/deserialized, preventing unintended exposure of fields. Logging the raw webhook payload instead of the parsed object ensures we capture the exact data received from the webhook provider, which is helpful for debugging and auditing purposes.