### PR TITLE
adding error type for test webhook endpoint

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -777,7 +777,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/TestWebhookError'
         '401':
           description: Unauthorized
           content:
@@ -2958,6 +2958,20 @@ components:
         response_body:
           type: string
           description: The raw body content returned by the webhook endpoint in response to the request
+    TestWebhookError:
+      allOf:
+        - $ref: '#/components/schemas/Error'
+        - type: object
+          properties:
+            code:
+              type: string
+              description: |
+                Error code indicating the type of webhook failure:
+                - `WEBHOOK_ENDPOINT_NOT_SET` (400) - Webhook URL is not configured
+                - `WEBHOOK_DELIVERY_ERROR` (400) - Service did not receive an expected response from webhook URL
+              enum:
+                - WEBHOOK_ENDPOINT_NOT_SET
+                - WEBHOOK_DELIVERY_ERROR
     Transaction:
       type: object
       required:

--- a/openapi/components/schemas/errors/TestWebhookError.yaml
+++ b/openapi/components/schemas/errors/TestWebhookError.yaml
@@ -1,0 +1,13 @@
+allOf:
+  - $ref: ../common/Error.yaml
+  - type: object
+    properties:
+      code:
+        type: string
+        description: |
+           Error code indicating the type of webhook failure:
+           - `WEBHOOK_ENDPOINT_NOT_SET` (400) - Webhook URL is not configured
+           - `WEBHOOK_DELIVERY_ERROR` (400) - Service did not receive an expected response from webhook URL
+        enum: 
+          - WEBHOOK_ENDPOINT_NOT_SET
+          - WEBHOOK_DELIVERY_ERROR

--- a/openapi/paths/webhooks/webhooks_test.yaml
+++ b/openapi/paths/webhooks/webhooks_test.yaml
@@ -18,7 +18,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/TestWebhookError.yaml
     '401':
       description: Unauthorized
       content:


### PR DESCRIPTION
### TL;DR

Added specific error codes for webhook testing failures.

### What changed?

- Created a new `TestWebhookError` schema that extends the base `Error` schema
- Added two specific error codes for webhook testing failures:
  - `WEBHOOK_ENDPOINT_NOT_SET`: When webhook URL is not configured
  - `WEBHOOK_DELIVERY_ERROR`: When service doesn't receive expected response from webhook URL
- Updated the error response schema reference in the webhook test endpoint from generic `Error` to the more specific `TestWebhookError`

### How to test?

1. Try testing a webhook without configuring a webhook URL and verify you receive the `WEBHOOK_ENDPOINT_NOT_SET` error code
2. Configure an invalid or non-responsive webhook URL and test it to verify you receive the `WEBHOOK_DELIVERY_ERROR` error code
3. Ensure the error responses include all the standard error fields plus the new `code` field with the appropriate enum value

### Why make this change?

This change improves error handling for webhook testing by providing more specific error codes that clearly indicate the reason for failure. This allows API consumers to better understand and troubleshoot webhook configuration issues, distinguishing between missing webhook URLs and delivery problems.