### PR TITLE
fix: updating proxy subdomain prefix

### DIFF
--- a/docusaurus-docs/docs/platform-configuration.md
+++ b/docusaurus-docs/docs/platform-configuration.md
@@ -139,9 +139,9 @@ Requirements for a valid UMA domain:
 - Must be a valid domain name format
 - Should be a domain that you control
 - Must proxy incoming requests to the UMAaaS API as follows:
-  - `https://<umaDomain>/.well-known/lnurlp/*` -> `https://<proxyUmaaasSubdomain>.uma.money/.well-known/lnurlp/*`
-  - `https://<umaDomain>/.well-known/lnurlpubkey` -> `https://<proxyUmaaasSubdomain>.uma.money/.well-known/lnurlpubkey`
-  - `https://<umaDomain>/.well-known/uma-configuration` -> `https://<proxyUmaaasSubdomain>.uma.money/.well-known/uma-configuration`
+  - `https://<umaDomain>/.well-known/lnurlp/*` -> `https://<proxyUmaaasSubdomain>.umaaas.uma.money/.well-known/lnurlp/*`
+  - `https://<umaDomain>/.well-known/lnurlpubkey` -> `https://<proxyUmaaasSubdomain>.umaaas.uma.money/.well-known/lnurlpubkey`
+  - `https://<umaDomain>/.well-known/uma-configuration` -> `https://<proxyUmaaasSubdomain>.umaaas.uma.money/.well-known/uma-configuration`
 
 ### Webhook Endpoint
 


### PR DESCRIPTION
### TL;DR

Updated the UMA domain proxy configuration to use the correct subdomain structure.

### What changed?

Modified the UMA domain proxy configuration in the platform documentation to point to the correct subdomain structure. Changed the target URLs from `<proxyUmaaasSubdomain>.uma.money` to `<proxyUmaaasSubdomain>.umaaas.uma.money` for all three well-known endpoints:
- `/.well-known/lnurlp/*`
- `/.well-known/lnurlpubkey`
- `/.well-known/uma-configuration`

### How to test?

1. Review the updated documentation to ensure the proxy configuration is correct
2. Verify that any existing proxy configurations are updated to use the new subdomain structure
3. Test a proxy setup with the new configuration to confirm it works properly

### Why make this change?

The previous documentation referenced an incorrect domain structure for proxying UMA requests. This change ensures users correctly configure their proxies to the proper `umaaas.uma.money` subdomain, preventing connectivity issues and ensuring proper functionality of the UMA service.