### PR TITLE
fix: fixing sandbox UMA sender address

### DIFF
--- a/samples/kotlin/umaaas-quickstart/frontend/src/components/forms/SandboxPayments.tsx
+++ b/samples/kotlin/umaaas-quickstart/frontend/src/components/forms/SandboxPayments.tsx
@@ -74,7 +74,7 @@ export default function SandboxPayments({ currUser, quoteResponse }: SandboxPaym
         userId: currUser.id,
         receivingCurrencyAmount: receivingAmountSmallestUnit,
         receivingCurrencyCode: receivingCurrencyCode,
-        senderUmaAddress: '$success.usd@sandbox.umaaas.money.dev.dev.sparkinfra.net',
+        senderUmaAddress: '$success.usd@sandbox.umaaas.uma.money',
       };
 
       const res = await fetch('/api/sandbox/receive', {


### PR DESCRIPTION
### TL;DR

Updated the sender UMA address in the sandbox payments component to use the new domain.

### What changed?

Changed the `senderUmaAddress` in the SandboxPayments component from `$success.usd@sandbox.umaaas.money.dev.dev.sparkinfra.net` to `$success.usd@sandbox.umaaas.uma.money`.

### How to test?

1. Navigate to the sandbox payments section in the frontend
2. Verify that payments are processed correctly with the new UMA address
3. Confirm that the sandbox environment properly recognizes the updated address format

### Why make this change?

This update aligns the sandbox environment with the new domain structure for UMA addresses, ensuring consistency across the platform and maintaining compatibility with the latest sandbox infrastructure.