### PR TITLE
adding 401 error type

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -127,7 +127,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '409':
           description: Conflict - User with the UMA address already exists
           content:
@@ -255,7 +255,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
   /users/{userId}:
     parameters:
       - name: userId
@@ -291,7 +291,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '404':
           description: User not found
           content:
@@ -420,7 +420,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '404':
           description: User not found
           content:
@@ -454,7 +454,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '404':
           description: User not found
           content:
@@ -514,7 +514,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
     get:
       summary: List tokens
       description: |
@@ -611,7 +611,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
   /tokens/{tokenId}:
     parameters:
       - name: tokenId
@@ -640,7 +640,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '404':
           description: Token not found
           content:
@@ -669,7 +669,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '404':
           description: Token not found
           content:
@@ -697,7 +697,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
     patch:
       summary: Update platform configuration
       description: Update the platform configuration settings
@@ -755,7 +755,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
   /webhooks/test:
     post:
       summary: Send a test webhook
@@ -783,7 +783,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
   /transactions/{transactionId}:
     parameters:
       - name: transactionId
@@ -812,7 +812,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '404':
           description: Transaction not found
           content:
@@ -955,7 +955,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
   /transactions/{transactionId}/approve:
     post:
       summary: Approve a pending incoming payment
@@ -1003,7 +1003,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '404':
           description: Transaction not found
           content:
@@ -1063,7 +1063,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '404':
           description: Transaction not found
           content:
@@ -1147,7 +1147,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '404':
           description: UMA address not found
           content:
@@ -1259,7 +1259,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '422':
           description: |
             Unprocessable Entity - Additional counterparty information required,
@@ -1311,7 +1311,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '404':
           description: Quote not found
           content:
@@ -1573,7 +1573,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
   /users/bulk/jobs/{jobId}:
     get:
       summary: Get bulk import job status
@@ -1610,7 +1610,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '404':
           description: Job not found
           content:
@@ -1673,7 +1673,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
   /invitations/{invitationCode}:
     get:
       summary: Get a specific UMA invitation by code.
@@ -1703,7 +1703,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '404':
           description: Invitation not found
           content:
@@ -1765,7 +1765,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '404':
           description: Invitation not found
           content:
@@ -1815,7 +1815,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '403':
           description: Forbidden - Only the platform which created the invitation can cancel it
           content:
@@ -1882,7 +1882,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '403':
           description: Forbidden - request was made with a production platform token
           content:
@@ -1957,7 +1957,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '403':
           description: Forbidden - request was made with a production platform token
           content:
@@ -2055,7 +2055,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
 webhooks:
   incoming-payment:
     post:
@@ -2182,7 +2182,7 @@ webhooks:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '403':
           description: |
             Forbidden - Payment rejected by the client.
@@ -2321,7 +2321,7 @@ webhooks:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '409':
           description: Conflict - Webhook has already been processed (duplicate webhookId)
           content:
@@ -2378,7 +2378,7 @@ webhooks:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '409':
           description: Conflict - Webhook has already been processed (duplicate webhookId)
           content:
@@ -2466,7 +2466,7 @@ webhooks:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '409':
           description: Conflict - Webhook has already been processed (duplicate webhookId)
           content:
@@ -2540,7 +2540,7 @@ webhooks:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error401'
         '409':
           description: Conflict - Webhook has already been processed (duplicate webhookId)
           content:
@@ -2924,6 +2924,25 @@ components:
         code:
           type: string
           description: Error code
+        message:
+          type: string
+          description: Error message
+        details:
+          type: object
+          description: Additional error details
+    Error401:
+      type: object
+      properties:
+        code:
+          type: string
+          description: |
+            | Error Code | Description |
+            |------------|-------------|
+            | UNAUTHORIZED | Issue with API credentials |
+            | INVALID_SIGNATURE | Counterparty UMA response signature is invalid | 
+          enum:
+            - UNAUTHORIZED
+            - INVALID_SIGNATURE
         message:
           type: string
           description: Error message

--- a/openapi/components/schemas/errors/Error401.yaml
+++ b/openapi/components/schemas/errors/Error401.yaml
@@ -1,0 +1,18 @@
+type: object
+properties:
+  code:
+    type: string
+    description: |
+      | Error Code | Description |
+      |------------|-------------|
+      | UNAUTHORIZED | Issue with API credentials |
+      | INVALID_SIGNATURE | Counterparty UMA response signature is invalid | 
+    enum:
+      - UNAUTHORIZED
+      - INVALID_SIGNATURE
+  message:
+    type: string
+    description: Error message
+  details:
+    type: object
+    description: Additional error details

--- a/openapi/paths/config/config.yaml
+++ b/openapi/paths/config/config.yaml
@@ -18,7 +18,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
 patch:
   summary: Update platform configuration
   description: Update the platform configuration settings
@@ -76,4 +76,4 @@ patch:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml

--- a/openapi/paths/invitations/invitations.yaml
+++ b/openapi/paths/invitations/invitations.yaml
@@ -62,4 +62,4 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml

--- a/openapi/paths/invitations/invitations_{invitationCode}.yaml
+++ b/openapi/paths/invitations/invitations_{invitationCode}.yaml
@@ -26,7 +26,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '404':
       description: Invitation not found
       content:

--- a/openapi/paths/invitations/invitations_{invitationCode}_cancel.yaml
+++ b/openapi/paths/invitations/invitations_{invitationCode}_cancel.yaml
@@ -50,7 +50,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '403':
       description: Forbidden - Only the platform which created the invitation can cancel it
       content:

--- a/openapi/paths/invitations/invitations_{invitationCode}_claim.yaml
+++ b/openapi/paths/invitations/invitations_{invitationCode}_claim.yaml
@@ -59,7 +59,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '404':
       description: Invitation not found
       content:

--- a/openapi/paths/quotes/quotes.yaml
+++ b/openapi/paths/quotes/quotes.yaml
@@ -126,7 +126,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '422':
       description: |
         Unprocessable Entity - Additional counterparty information required,

--- a/openapi/paths/quotes/quotes_{quoteId}.yaml
+++ b/openapi/paths/quotes/quotes_{quoteId}.yaml
@@ -31,7 +31,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '404':
       description: Quote not found
       content:

--- a/openapi/paths/receiver/receiver_{receiverUmaAddress}.yaml
+++ b/openapi/paths/receiver/receiver_{receiverUmaAddress}.yaml
@@ -75,7 +75,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '404':
       description: UMA address not found
       content:

--- a/openapi/paths/sandbox/sandbox_receive.yaml
+++ b/openapi/paths/sandbox/sandbox_receive.yaml
@@ -66,7 +66,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '403':
       description: Forbidden - request was made with a production platform token
       content:

--- a/openapi/paths/sandbox/sandbox_send.yaml
+++ b/openapi/paths/sandbox/sandbox_send.yaml
@@ -55,7 +55,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '403':
       description: Forbidden - request was made with a production platform token
       content:

--- a/openapi/paths/tokens/tokens.yaml
+++ b/openapi/paths/tokens/tokens.yaml
@@ -44,7 +44,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
 get:
   summary: List tokens
   description: >
@@ -148,4 +148,4 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml

--- a/openapi/paths/tokens/tokens_{tokenId}.yaml
+++ b/openapi/paths/tokens/tokens_{tokenId}.yaml
@@ -25,7 +25,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '404':
       description: Token not found
       content:
@@ -54,7 +54,7 @@ delete:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '404':
       description: Token not found
       content:

--- a/openapi/paths/transactions/transactions.yaml
+++ b/openapi/paths/transactions/transactions.yaml
@@ -137,4 +137,4 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml

--- a/openapi/paths/transactions/transactions_{transactionId}.yaml
+++ b/openapi/paths/transactions/transactions_{transactionId}.yaml
@@ -25,7 +25,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '404':
       description: Transaction not found
       content:

--- a/openapi/paths/transactions/transactions_{transactionId}_approve.yaml
+++ b/openapi/paths/transactions/transactions_{transactionId}_approve.yaml
@@ -50,7 +50,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '404':
       description: Transaction not found
       content:

--- a/openapi/paths/transactions/transactions_{transactionId}_reject.yaml
+++ b/openapi/paths/transactions/transactions_{transactionId}_reject.yaml
@@ -49,7 +49,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '404':
       description: Transaction not found
       content:

--- a/openapi/paths/uma_providers/uma_providers.yaml
+++ b/openapi/paths/uma_providers/uma_providers.yaml
@@ -80,4 +80,4 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml

--- a/openapi/paths/users/users.yaml
+++ b/openapi/paths/users/users.yaml
@@ -92,7 +92,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '409':
       description: Conflict - User with the UMA address already exists
       content:
@@ -227,4 +227,4 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml

--- a/openapi/paths/users/users_bulk_csv.yaml
+++ b/openapi/paths/users/users_bulk_csv.yaml
@@ -184,4 +184,4 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml

--- a/openapi/paths/users/users_bulk_jobs_{jobId}.yaml
+++ b/openapi/paths/users/users_bulk_jobs_{jobId}.yaml
@@ -40,7 +40,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '404':
       description: Job not found
       content:

--- a/openapi/paths/users/users_{userId}.yaml
+++ b/openapi/paths/users/users_{userId}.yaml
@@ -32,7 +32,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '404':
       description: User not found
       content:
@@ -161,7 +161,7 @@ patch:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '404':
       description: User not found
       content:
@@ -195,7 +195,7 @@ delete:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml
     '404':
       description: User not found
       content:

--- a/openapi/paths/webhooks/webhooks_test.yaml
+++ b/openapi/paths/webhooks/webhooks_test.yaml
@@ -24,4 +24,4 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error401.yaml

--- a/openapi/webhooks/bulk-upload.yaml
+++ b/openapi/webhooks/bulk-upload.yaml
@@ -91,7 +91,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/common/Error.yaml
+            $ref: ../components/schemas/errors/Error401.yaml
     '409':
       description: Conflict - Webhook has already been processed (duplicate webhookId)
       content:

--- a/openapi/webhooks/incoming-payment.yaml
+++ b/openapi/webhooks/incoming-payment.yaml
@@ -164,7 +164,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/common/Error.yaml
+            $ref: ../components/schemas/errors/Error401.yaml
     '403':
       description: |
         Forbidden - Payment rejected by the client.

--- a/openapi/webhooks/invitation-claimed.yaml
+++ b/openapi/webhooks/invitation-claimed.yaml
@@ -85,7 +85,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/common/Error.yaml
+            $ref: ../components/schemas/errors/Error401.yaml
     '409':
       description: Conflict - Webhook has already been processed (duplicate webhookId)
       content:

--- a/openapi/webhooks/outgoing-payment.yaml
+++ b/openapi/webhooks/outgoing-payment.yaml
@@ -126,7 +126,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/common/Error.yaml
+            $ref: ../components/schemas/errors/Error401.yaml
     '409':
       description: Conflict - Webhook has already been processed (duplicate webhookId)
       content:

--- a/openapi/webhooks/test-webhook.yaml
+++ b/openapi/webhooks/test-webhook.yaml
@@ -64,7 +64,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../components/schemas/common/Error.yaml
+            $ref: ../components/schemas/errors/Error401.yaml
     '409':
       description: Conflict - Webhook has already been processed (duplicate webhookId)
       content:


### PR DESCRIPTION
### TL;DR

Added a specific `Error401` schema for unauthorized responses and updated all API endpoints to reference it.

### What changed?

- Created a new `Error401.yaml` schema file specifically for 401 unauthorized responses
- Added the `Error401` schema to the main OpenAPI specification with specific error codes:
  - `UNAUTHORIZED`: Issue with API credentials
  - `INVALID_SIGNATURE`: Counterparty UMA response signature is invalid
- Updated all API endpoints to reference the new `Error401` schema instead of the generic `Error` schema for 401 responses
- This change affects all API paths and webhooks in the specification

### How to test?

1. Verify that the new `Error401` schema is correctly defined in the OpenAPI specification
2. Test API endpoints with invalid credentials to confirm they return the appropriate error format
3. Validate that the documentation correctly displays the specific error codes for 401 responses

### Why make this change?

This change improves API error handling by providing more specific error information for unauthorized responses. By separating the 401 error schema from the generic error schema, developers can more easily understand and handle authentication-related errors. The specific error codes (`UNAUTHORIZED` and `INVALID_SIGNATURE`) provide clearer guidance on what went wrong with authentication, improving the developer experience.