### PR TITLE
feat: adding http 404 error messages

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -297,7 +297,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error404'
     patch:
       summary: Update user by ID
       description: Update a user's metadata by their system-generated ID
@@ -426,7 +426,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error404'
     delete:
       summary: Delete user by ID
       description: Delete a user by their system-generated ID
@@ -460,7 +460,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error404'
         '410':
           description: User deleted already
           content:
@@ -646,7 +646,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error404'
     delete:
       summary: Delete API token by ID
       description: Delete an API token by their system-generated ID
@@ -675,7 +675,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error404'
   /config:
     get:
       summary: Get platform configuration
@@ -818,7 +818,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error404'
   /transactions:
     get:
       summary: List transactions
@@ -1009,7 +1009,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error404'
         '409':
           description: Conflict - Payment is not in a pending state or has already been processed or timed out.
           content:
@@ -1069,7 +1069,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error404'
         '409':
           description: Conflict - Payment is not in a pending state or has already been processed or timed out.
           content:
@@ -1153,7 +1153,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error404'
   /quotes:
     post:
       summary: Create a payment quote
@@ -1317,7 +1317,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error404'
   /quotes/{quoteId}/retry:
     post:
       summary: Retry an incomplete payment
@@ -1616,7 +1616,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error404'
   /invitations:
     post:
       summary: Create an UMA invitation from a given platform user.
@@ -1709,7 +1709,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error404'
   /invitations/{invitationCode}/claim:
     post:
       summary: Claim an UMA invitation
@@ -1771,7 +1771,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error404'
   /invitations/{invitationCode}/cancel:
     post:
       summary: Cancel an UMA invitation
@@ -1827,7 +1827,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error404'
   /sandbox/send:
     post:
       summary: Simulate sending funds
@@ -1894,7 +1894,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error404'
   /sandbox/receive:
     post:
       summary: Simulate payment send to test receiving a payment
@@ -1969,7 +1969,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Error'
+                $ref: '#/components/schemas/Error404'
   /uma-providers:
     get:
       summary: This endpoint provides a list of counterparties that are available.
@@ -3012,6 +3012,37 @@ components:
         code:
           type: string
           description: Error code
+        message:
+          type: string
+          description: Error message
+        details:
+          type: object
+          description: Additional error details
+    Error404:
+      type: object
+      properties:
+        code:
+          type: string
+          description: |
+            | Error Code | Description |
+            |------------|-------------|
+            | TRANSACTION_NOT_FOUND | Transaction not found |
+            | INVITATION_NOT_FOUND | Invitation not found |
+            | USER_NOT_FOUND | User not found |
+            | QUOTE_NOT_FOUND | Quote not found |
+            | LOOKUP_REQUEST_NOT_FOUND | Lookup request not found |
+            | TOKEN_NOT_FOUND | Token not found |
+            | BULK_UPLOAD_JOB_NOT_FOUND | Bulk upload job not found |
+            | REFERENCE_NOT_FOUND | Reference not found | 
+          enum:
+            - TRANSACTION_NOT_FOUND
+            - INVITATION_NOT_FOUND
+            - USER_NOT_FOUND
+            - QUOTE_NOT_FOUND
+            - LOOKUP_REQUEST_NOT_FOUND
+            - TOKEN_NOT_FOUND
+            - BULK_UPLOAD_JOB_NOT_FOUND
+            - REFERENCE_NOT_FOUND
         message:
           type: string
           description: Error message

--- a/openapi/components/schemas/errors/Error404.yaml
+++ b/openapi/components/schemas/errors/Error404.yaml
@@ -1,0 +1,30 @@
+type: object
+properties:
+  code:
+    type: string
+    description: |
+      | Error Code | Description |
+      |------------|-------------|
+      | TRANSACTION_NOT_FOUND | Transaction not found |
+      | INVITATION_NOT_FOUND | Invitation not found |
+      | USER_NOT_FOUND | User not found |
+      | QUOTE_NOT_FOUND | Quote not found |
+      | LOOKUP_REQUEST_NOT_FOUND | Lookup request not found |
+      | TOKEN_NOT_FOUND | Token not found |
+      | BULK_UPLOAD_JOB_NOT_FOUND | Bulk upload job not found |
+      | REFERENCE_NOT_FOUND | Reference not found | 
+    enum:
+      - TRANSACTION_NOT_FOUND
+      - INVITATION_NOT_FOUND
+      - USER_NOT_FOUND
+      - QUOTE_NOT_FOUND
+      - LOOKUP_REQUEST_NOT_FOUND
+      - TOKEN_NOT_FOUND
+      - BULK_UPLOAD_JOB_NOT_FOUND
+      - REFERENCE_NOT_FOUND
+  message:
+    type: string
+    description: Error message
+  details:
+    type: object
+    description: Additional error details

--- a/openapi/paths/invitations/invitations_{invitationCode}.yaml
+++ b/openapi/paths/invitations/invitations_{invitationCode}.yaml
@@ -32,4 +32,4 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error404.yaml

--- a/openapi/paths/invitations/invitations_{invitationCode}_cancel.yaml
+++ b/openapi/paths/invitations/invitations_{invitationCode}_cancel.yaml
@@ -62,4 +62,4 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error404.yaml

--- a/openapi/paths/invitations/invitations_{invitationCode}_claim.yaml
+++ b/openapi/paths/invitations/invitations_{invitationCode}_claim.yaml
@@ -65,4 +65,4 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error404.yaml

--- a/openapi/paths/quotes/quotes_{quoteId}.yaml
+++ b/openapi/paths/quotes/quotes_{quoteId}.yaml
@@ -37,4 +37,4 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error404.yaml

--- a/openapi/paths/receiver/receiver_{receiverUmaAddress}.yaml
+++ b/openapi/paths/receiver/receiver_{receiverUmaAddress}.yaml
@@ -81,4 +81,4 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error404.yaml

--- a/openapi/paths/sandbox/sandbox_receive.yaml
+++ b/openapi/paths/sandbox/sandbox_receive.yaml
@@ -78,4 +78,4 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error404.yaml

--- a/openapi/paths/sandbox/sandbox_send.yaml
+++ b/openapi/paths/sandbox/sandbox_send.yaml
@@ -67,4 +67,4 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error404.yaml

--- a/openapi/paths/tokens/tokens_{tokenId}.yaml
+++ b/openapi/paths/tokens/tokens_{tokenId}.yaml
@@ -31,7 +31,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error404.yaml
 delete:
   summary: Delete API token by ID
   description: Delete an API token by their system-generated ID
@@ -60,4 +60,4 @@ delete:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error404.yaml

--- a/openapi/paths/transactions/transactions_{transactionId}.yaml
+++ b/openapi/paths/transactions/transactions_{transactionId}.yaml
@@ -31,4 +31,4 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error404.yaml

--- a/openapi/paths/transactions/transactions_{transactionId}_approve.yaml
+++ b/openapi/paths/transactions/transactions_{transactionId}_approve.yaml
@@ -56,7 +56,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error404.yaml
     '409':
       description: >-
         Conflict - Payment is not in a pending state or has already been

--- a/openapi/paths/transactions/transactions_{transactionId}_reject.yaml
+++ b/openapi/paths/transactions/transactions_{transactionId}_reject.yaml
@@ -55,7 +55,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error404.yaml
     '409':
       description: >-
         Conflict - Payment is not in a pending state or has already been

--- a/openapi/paths/users/users_bulk_jobs_{jobId}.yaml
+++ b/openapi/paths/users/users_bulk_jobs_{jobId}.yaml
@@ -46,4 +46,4 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error404.yaml

--- a/openapi/paths/users/users_{userId}.yaml
+++ b/openapi/paths/users/users_{userId}.yaml
@@ -38,7 +38,7 @@ get:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error404.yaml
 patch:
   summary: Update user by ID
   description: Update a user's metadata by their system-generated ID
@@ -167,7 +167,7 @@ patch:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error404.yaml
 delete:
   summary: Delete user by ID
   description: Delete a user by their system-generated ID
@@ -201,7 +201,7 @@ delete:
       content:
         application/json:
           schema:
-            $ref: ../../components/schemas/common/Error.yaml
+            $ref: ../../components/schemas/errors/Error404.yaml
     '410':
       description: User deleted already
       content:


### PR DESCRIPTION
### TL;DR

Added a specific Error404 schema for 404 responses across the API.

### What changed?

- Created a new `Error404.yaml` schema in the `openapi/components/schemas/errors/` directory
- Added specific error codes for 404 responses (e.g., `TRANSACTION_NOT_FOUND`, `USER_NOT_FOUND`, etc.)
- Updated all 404 response references across the API to use the new `Error404` schema instead of the generic `Error` schema
- Added the `Error404` schema definition to the main OpenAPI specification

### How to test?

1. Validate the OpenAPI specification to ensure it's still valid
2. Check that all 404 responses now reference the new `Error404` schema
3. Verify that the error codes in the `Error404` schema match the expected 404 error scenarios

### Why make this change?

This change improves API documentation by providing more specific error information for 404 responses. By defining specific error codes for different types of "not found" scenarios, API consumers can better understand and handle these errors. This makes the API more user-friendly and reduces ambiguity when resources aren't found.