### PR TITLE
feat: adding http 500 error codes

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -134,6 +134,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error409'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
     get:
       summary: List users
       description: |
@@ -256,6 +262,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /users/{userId}:
     parameters:
       - name: userId
@@ -298,6 +310,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
     patch:
       summary: Update user by ID
       description: Update a user's metadata by their system-generated ID
@@ -427,6 +445,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
     delete:
       summary: Delete user by ID
       description: Delete a user by their system-generated ID
@@ -467,6 +491,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /tokens:
     post:
       summary: Create a new API token
@@ -515,6 +545,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
     get:
       summary: List tokens
       description: |
@@ -612,6 +648,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /tokens/{tokenId}:
     parameters:
       - name: tokenId
@@ -647,6 +689,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
     delete:
       summary: Delete API token by ID
       description: Delete an API token by their system-generated ID
@@ -676,6 +724,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /config:
     get:
       summary: Get platform configuration
@@ -698,6 +752,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
     patch:
       summary: Update platform configuration
       description: Update the platform configuration settings
@@ -756,6 +816,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /webhooks/test:
     post:
       summary: Send a test webhook
@@ -784,6 +850,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /transactions/{transactionId}:
     parameters:
       - name: transactionId
@@ -819,6 +891,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /transactions:
     get:
       summary: List transactions
@@ -956,6 +1034,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /transactions/{transactionId}/approve:
     post:
       summary: Approve a pending incoming payment
@@ -1016,6 +1100,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error409'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /transactions/{transactionId}/reject:
     post:
       summary: Reject a pending incoming payment
@@ -1076,6 +1166,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error409'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /receiver/{receiverUmaAddress}:
     get:
       summary: Look up a UMA address for payment
@@ -1166,6 +1262,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error424'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /quotes:
     post:
       summary: Create a payment quote
@@ -1284,6 +1386,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error424'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /quotes/{quoteId}:
     get:
       summary: Get quote by ID
@@ -1322,6 +1430,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /quotes/{quoteId}/retry:
     post:
       summary: Retry an incomplete payment
@@ -1578,6 +1692,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /users/bulk/jobs/{jobId}:
     get:
       summary: Get bulk import job status
@@ -1621,6 +1741,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /invitations:
     post:
       summary: Create an UMA invitation from a given platform user.
@@ -1678,6 +1804,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /invitations/{invitationCode}:
     get:
       summary: Get a specific UMA invitation by code.
@@ -1714,6 +1846,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /invitations/{invitationCode}/claim:
     post:
       summary: Claim an UMA invitation
@@ -1776,6 +1914,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /invitations/{invitationCode}/cancel:
     post:
       summary: Cancel an UMA invitation
@@ -1832,6 +1976,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /sandbox/send:
     post:
       summary: Simulate sending funds
@@ -1899,6 +2049,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /sandbox/receive:
     post:
       summary: Simulate payment send to test receiving a payment
@@ -1974,6 +2130,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error404'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
   /uma-providers:
     get:
       summary: This endpoint provides a list of counterparties that are available.
@@ -2060,6 +2222,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error401'
+        '500':
+          description: Internal service error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error500'
 webhooks:
   incoming-payment:
     post:
@@ -3004,6 +3172,27 @@ components:
           enum:
             - UNAUTHORIZED
             - INVALID_SIGNATURE
+        message:
+          type: string
+          description: Error message
+        details:
+          type: object
+          description: Additional error details
+    Error500:
+      type: object
+      properties:
+        code:
+          type: string
+          description: |
+            | Error Code | Description |
+            |------------|-------------|
+            | INTERNAL | Internal server error |
+            | GRID_SWITCH_ERROR | Grid switch error |
+            | INTERNAL_ERROR | Internal server error | 
+          enum:
+            - INTERNAL
+            - GRID_SWITCH_ERROR
+            - INTERNAL_ERROR
         message:
           type: string
           description: Error message

--- a/openapi/components/schemas/errors/Error401.yaml
+++ b/openapi/components/schemas/errors/Error401.yaml
@@ -6,7 +6,7 @@ properties:
       | Error Code | Description |
       |------------|-------------|
       | UNAUTHORIZED | Issue with API credentials |
-      | INVALID_SIGNATURE | Counterparty UMA response signature is invalid | 
+      | INVALID_SIGNATURE | Signature header is invalid | 
     enum:
       - UNAUTHORIZED
       - INVALID_SIGNATURE

--- a/openapi/components/schemas/errors/Error500.yaml
+++ b/openapi/components/schemas/errors/Error500.yaml
@@ -1,0 +1,20 @@
+type: object
+properties:
+  code:
+    type: string
+    description: |
+      | Error Code | Description |
+      |------------|-------------|
+      | INTERNAL | Internal server error |
+      | GRID_SWITCH_ERROR | Grid switch error |
+      | INTERNAL_ERROR | Internal server error | 
+    enum:
+      - INTERNAL
+      - GRID_SWITCH_ERROR
+      - INTERNAL_ERROR
+  message:
+    type: string
+    description: Error message
+  details:
+    type: object
+    description: Additional error details

--- a/openapi/paths/config/config.yaml
+++ b/openapi/paths/config/config.yaml
@@ -19,6 +19,12 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error401.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml
 patch:
   summary: Update platform configuration
   description: Update the platform configuration settings
@@ -77,3 +83,9 @@ patch:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error401.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/invitations/invitations.yaml
+++ b/openapi/paths/invitations/invitations.yaml
@@ -63,3 +63,9 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error401.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/invitations/invitations_{invitationCode}.yaml
+++ b/openapi/paths/invitations/invitations_{invitationCode}.yaml
@@ -33,3 +33,9 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error404.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/invitations/invitations_{invitationCode}_cancel.yaml
+++ b/openapi/paths/invitations/invitations_{invitationCode}_cancel.yaml
@@ -63,3 +63,9 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error404.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/invitations/invitations_{invitationCode}_claim.yaml
+++ b/openapi/paths/invitations/invitations_{invitationCode}_claim.yaml
@@ -66,3 +66,9 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error404.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/quotes/quotes.yaml
+++ b/openapi/paths/quotes/quotes.yaml
@@ -139,3 +139,9 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error424.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/quotes/quotes_{quoteId}.yaml
+++ b/openapi/paths/quotes/quotes_{quoteId}.yaml
@@ -38,3 +38,9 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error404.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/receiver/receiver_{receiverUmaAddress}.yaml
+++ b/openapi/paths/receiver/receiver_{receiverUmaAddress}.yaml
@@ -94,3 +94,9 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error424.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/sandbox/sandbox_receive.yaml
+++ b/openapi/paths/sandbox/sandbox_receive.yaml
@@ -79,3 +79,9 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error404.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/sandbox/sandbox_send.yaml
+++ b/openapi/paths/sandbox/sandbox_send.yaml
@@ -68,3 +68,9 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error404.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/tokens/tokens.yaml
+++ b/openapi/paths/tokens/tokens.yaml
@@ -45,6 +45,12 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error401.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml
 get:
   summary: List tokens
   description: >
@@ -149,3 +155,9 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error401.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/tokens/tokens_{tokenId}.yaml
+++ b/openapi/paths/tokens/tokens_{tokenId}.yaml
@@ -32,6 +32,12 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error404.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml
 delete:
   summary: Delete API token by ID
   description: Delete an API token by their system-generated ID
@@ -61,3 +67,9 @@ delete:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error404.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/transactions/transactions.yaml
+++ b/openapi/paths/transactions/transactions.yaml
@@ -138,3 +138,9 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error401.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/transactions/transactions_{transactionId}.yaml
+++ b/openapi/paths/transactions/transactions_{transactionId}.yaml
@@ -32,3 +32,9 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error404.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/transactions/transactions_{transactionId}_approve.yaml
+++ b/openapi/paths/transactions/transactions_{transactionId}_approve.yaml
@@ -65,3 +65,9 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error409.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/transactions/transactions_{transactionId}_reject.yaml
+++ b/openapi/paths/transactions/transactions_{transactionId}_reject.yaml
@@ -64,3 +64,9 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error409.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/uma_providers/uma_providers.yaml
+++ b/openapi/paths/uma_providers/uma_providers.yaml
@@ -81,3 +81,9 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error401.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/users/users.yaml
+++ b/openapi/paths/users/users.yaml
@@ -99,6 +99,12 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error409.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml
 get:
   summary: List users
   description: >
@@ -228,3 +234,9 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error401.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/users/users_bulk_csv.yaml
+++ b/openapi/paths/users/users_bulk_csv.yaml
@@ -185,3 +185,9 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error401.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/users/users_bulk_jobs_{jobId}.yaml
+++ b/openapi/paths/users/users_bulk_jobs_{jobId}.yaml
@@ -47,3 +47,9 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error404.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/users/users_{userId}.yaml
+++ b/openapi/paths/users/users_{userId}.yaml
@@ -39,6 +39,12 @@ get:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error404.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml
 patch:
   summary: Update user by ID
   description: Update a user's metadata by their system-generated ID
@@ -168,6 +174,12 @@ patch:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error404.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml
 delete:
   summary: Delete user by ID
   description: Delete a user by their system-generated ID
@@ -208,3 +220,9 @@ delete:
         application/json:
           schema:
             $ref: ../../components/schemas/common/Error.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml

--- a/openapi/paths/webhooks/webhooks_test.yaml
+++ b/openapi/paths/webhooks/webhooks_test.yaml
@@ -25,3 +25,9 @@ post:
         application/json:
           schema:
             $ref: ../../components/schemas/errors/Error401.yaml
+    '500':
+      description: Internal service error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/errors/Error500.yaml


### PR DESCRIPTION
### TL;DR

Added 500 error response definitions to all API endpoints.

### What changed?

- Added a new `Error500` schema definition that includes error codes for internal server errors:
  - `INTERNAL`
  - `GRID_SWITCH_ERROR`
  - `INTERNAL_ERROR`
- Added 500 error response definitions to all API endpoints in the OpenAPI specification
- Created a new file `openapi/components/schemas/errors/Error500.yaml` with the error schema definition

### How to test?

1. Validate the OpenAPI specification to ensure it's valid after these changes
2. Check that all endpoints now include the 500 error response
3. Verify that the error schema includes the appropriate error codes and descriptions

### Why make this change?

This change improves the API documentation by explicitly defining how internal server errors are communicated to API consumers. By standardizing the 500 error response across all endpoints, developers will have a consistent way to handle server-side errors in their applications, improving error handling and debugging capabilities.