### PR TITLE
fix: fixing schema for payment instructions

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3160,22 +3160,18 @@ components:
       allOf:
         - $ref: '#/components/schemas/PaymentBankAccountInfo'
         - $ref: '#/components/schemas/ClabeAccountInfo'
-        - type: object
     PaymentUsAccountInfo:
       allOf:
         - $ref: '#/components/schemas/PaymentBankAccountInfo'
         - $ref: '#/components/schemas/UsAccountInfo'
-        - type: object
     PaymentPixAccountInfo:
       allOf:
         - $ref: '#/components/schemas/PaymentBankAccountInfo'
         - $ref: '#/components/schemas/PixAccountInfo'
-        - type: object
     PaymentIbanAccountInfo:
       allOf:
         - $ref: '#/components/schemas/PaymentBankAccountInfo'
         - $ref: '#/components/schemas/IbanAccountInfo'
-        - type: object
     PaymentFboAccountInfo:
       allOf:
         - $ref: '#/components/schemas/PaymentBankAccountInfo'
@@ -3200,7 +3196,6 @@ components:
       allOf:
         - $ref: '#/components/schemas/PaymentBankAccountInfo'
         - $ref: '#/components/schemas/UpiAccountInfo'
-        - type: object
     PaymentInstructions:
       type: object
       required:
@@ -3436,7 +3431,22 @@ components:
             DATE_OF_BIRTH: '1990-01-01'
             NATIONALITY: FR
         paymentInstructions:
-          $ref: '#/components/schemas/PaymentInstructions'
+          oneOf:
+            - $ref: '#/components/schemas/PaymentClabeAccountInfo'
+            - $ref: '#/components/schemas/PaymentUsAccountInfo'
+            - $ref: '#/components/schemas/PaymentPixAccountInfo'
+            - $ref: '#/components/schemas/PaymentIbanAccountInfo'
+            - $ref: '#/components/schemas/PaymentFboAccountInfo'
+            - $ref: '#/components/schemas/PaymentUpiAccountInfo'
+          discriminator:
+            propertyName: accountType
+            mapping:
+              CLABE: '#/components/schemas/PaymentClabeAccountInfo'
+              US_ACCOUNT: '#/components/schemas/PaymentUsAccountInfo'
+              PIX: '#/components/schemas/PaymentPixAccountInfo'
+              IBAN: '#/components/schemas/PaymentIbanAccountInfo'
+              FBO: '#/components/schemas/PaymentFboAccountInfo'
+              UPI: '#/components/schemas/PaymentUpiAccountInfo'
         status:
           type: string
           enum:

--- a/openapi/components/schemas/common/PaymentClabeAccountInfo.yaml
+++ b/openapi/components/schemas/common/PaymentClabeAccountInfo.yaml
@@ -1,4 +1,3 @@
 allOf:
   - $ref: ./PaymentBankAccountInfo.yaml
   - $ref: ./ClabeAccountInfo.yaml
-  - type: object

--- a/openapi/components/schemas/common/PaymentIbanAccountInfo.yaml
+++ b/openapi/components/schemas/common/PaymentIbanAccountInfo.yaml
@@ -1,4 +1,3 @@
 allOf:
   - $ref: ./PaymentBankAccountInfo.yaml
   - $ref: ./IbanAccountInfo.yaml
-  - type: object

--- a/openapi/components/schemas/common/PaymentPixAccountInfo.yaml
+++ b/openapi/components/schemas/common/PaymentPixAccountInfo.yaml
@@ -1,4 +1,3 @@
 allOf:
   - $ref: ./PaymentBankAccountInfo.yaml
   - $ref: ./PixAccountInfo.yaml
-  - type: object

--- a/openapi/components/schemas/common/PaymentUpiAccountInfo.yaml
+++ b/openapi/components/schemas/common/PaymentUpiAccountInfo.yaml
@@ -1,4 +1,3 @@
 allOf:
   - $ref: ./PaymentBankAccountInfo.yaml
   - $ref: ./UpiAccountInfo.yaml
-  - type: object

--- a/openapi/components/schemas/common/PaymentUsAccountInfo.yaml
+++ b/openapi/components/schemas/common/PaymentUsAccountInfo.yaml
@@ -1,4 +1,3 @@
 allOf:
   - $ref: ./PaymentBankAccountInfo.yaml
   - $ref: ./UsAccountInfo.yaml
-  - type: object

--- a/openapi/components/schemas/quotes/Quote.yaml
+++ b/openapi/components/schemas/quotes/Quote.yaml
@@ -63,7 +63,22 @@ properties:
       DATE_OF_BIRTH: '1990-01-01'
       NATIONALITY: FR
   paymentInstructions:
-    $ref: ../common/PaymentInstructions.yaml
+    oneOf:
+      - $ref: ../common/PaymentClabeAccountInfo.yaml
+      - $ref: ../common/PaymentUsAccountInfo.yaml
+      - $ref: ../common/PaymentPixAccountInfo.yaml
+      - $ref: ../common/PaymentIbanAccountInfo.yaml
+      - $ref: ../common/PaymentFboAccountInfo.yaml
+      - $ref: ../common/PaymentUpiAccountInfo.yaml
+    discriminator:
+      propertyName: accountType
+      mapping:
+        CLABE: ../common/PaymentClabeAccountInfo.yaml
+        US_ACCOUNT: ../common/PaymentUsAccountInfo.yaml
+        PIX: ../common/PaymentPixAccountInfo.yaml
+        IBAN: ../common/PaymentIbanAccountInfo.yaml
+        FBO: ../common/PaymentFboAccountInfo.yaml
+        UPI: ../common/PaymentUpiAccountInfo.yaml
   status:
     type: string
     enum:


### PR DESCRIPTION
### TL;DR

Updated the `PaymentBankAccountInfo` schema to use `allOf` and `oneOf` for better type validation.

### What changed?

Modified the `PaymentBankAccountInfo` schema in both the consolidated OpenAPI file and the component schema file to:
- Restructure it using `allOf` to maintain the required `accountType` property
- Add a `oneOf` constraint that enforces the object must match one of the specific account types:
  - `PaymentClabeAccountInfo`
  - `PaymentUsAccountInfo`
  - `PaymentPixAccountInfo`
  - `PaymentIbanAccountInfo`
  - `PaymentFboAccountInfo`
  - `PaymentUpiAccountInfo`
- Kept the existing discriminator configuration

### How to test?

1. Validate the OpenAPI schema to ensure it's still valid
2. Test API requests that use the `PaymentBankAccountInfo` schema to confirm they properly validate against the new structure
3. Verify that client code generation tools correctly handle the updated schema

### Why make this change?

This change improves schema validation by explicitly defining that a `PaymentBankAccountInfo` object must conform to one of the specific account type schemas. The `oneOf` constraint ensures that API consumers provide all required fields for the specific account type they're using, leading to better validation and more accurate API documentation.