### PR TITLE
feat: adding union error object and status codes to discriminate on for stainless

### DIFF
--- a/.redocly.lint-ignore.yaml
+++ b/.redocly.lint-ignore.yaml
@@ -1,0 +1,5 @@
+# This file instructs Redocly's linter to ignore the rules contained for specific parts of your API.
+# See https://redocly.com/docs/cli/ for more information.
+openapi.yaml:
+  no-unused-components:
+    - '#/components/schemas/AllErrors'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -796,6 +796,9 @@ paths:
                 - currencyCode: USD
                   minAmount: 100
                   maxAmount: 1000000
+                  enabledTransactionTypes:
+                    - OUTGOING
+                    - INCOMING
                   requiredCounterpartyFields:
                     - name: FULL_NAME
                       mandatory: true
@@ -2762,6 +2765,17 @@ components:
 
         If the signature verification succeeds, the webhook is authentic. If not, it should be rejected.
   schemas:
+    AllErrors:
+      anyOf:
+        - $ref: '#/components/schemas/Error400'
+        - $ref: '#/components/schemas/Error401'
+        - $ref: '#/components/schemas/Error403'
+        - $ref: '#/components/schemas/Error404'
+        - $ref: '#/components/schemas/Error409'
+        - $ref: '#/components/schemas/Error412'
+        - $ref: '#/components/schemas/Error424'
+        - $ref: '#/components/schemas/Error500'
+        - $ref: '#/components/schemas/Error501'
     UserType:
       type: string
       enum:
@@ -3115,6 +3129,11 @@ components:
     Error400:
       type: object
       properties:
+        status:
+          enum:
+            - 400
+          type: integer
+          description: HTTP status code
         code:
           type: string
           description: |
@@ -3184,13 +3203,18 @@ components:
     Error401:
       type: object
       properties:
+        status:
+          enum:
+            - 401
+          type: integer
+          description: HTTP status code
         code:
           type: string
           description: |
             | Error Code | Description |
             |------------|-------------|
             | UNAUTHORIZED | Issue with API credentials |
-            | INVALID_SIGNATURE | Counterparty UMA response signature is invalid | 
+            | INVALID_SIGNATURE | Signature header is invalid | 
           enum:
             - UNAUTHORIZED
             - INVALID_SIGNATURE
@@ -3203,6 +3227,11 @@ components:
     Error500:
       type: object
       properties:
+        status:
+          enum:
+            - 500
+          type: integer
+          description: HTTP status code
         code:
           type: string
           description: |
@@ -3224,6 +3253,11 @@ components:
     Error409:
       type: object
       properties:
+        status:
+          enum:
+            - 409
+          type: integer
+          description: HTTP status code
         code:
           type: string
           description: |
@@ -3243,6 +3277,11 @@ components:
     Error501:
       type: object
       properties:
+        status:
+          enum:
+            - 501
+          type: integer
+          description: HTTP status code
         code:
           type: string
           description: |
@@ -3262,6 +3301,11 @@ components:
     Error404:
       type: object
       properties:
+        status:
+          enum:
+            - 404
+          type: integer
+          description: HTTP status code
         code:
           type: string
           description: |
@@ -3440,6 +3484,9 @@ components:
           items:
             $ref: '#/components/schemas/TransactionType'
           description: List of transaction types that are enabled for this currency.
+          example:
+            - OUTGOING
+            - INCOMING
       required:
         - currencyCode
         - minAmount
@@ -3913,6 +3960,11 @@ components:
     Error412:
       type: object
       properties:
+        status:
+          enum:
+            - 412
+          type: integer
+          description: HTTP status code
         code:
           type: string
           description: |
@@ -3930,6 +3982,11 @@ components:
     Error424:
       type: object
       properties:
+        status:
+          enum:
+            - 424
+          type: integer
+          description: HTTP status code
         code:
           type: string
           description: |
@@ -4161,6 +4218,11 @@ components:
     Error403:
       type: object
       properties:
+        status:
+          enum:
+            - 403
+          type: integer
+          description: HTTP status code
         code:
           type: string
           description: |

--- a/openapi/components/schemas/config/PlatformCurrencyConfig.yaml
+++ b/openapi/components/schemas/config/PlatformCurrencyConfig.yaml
@@ -62,6 +62,9 @@ properties:
     items:
       $ref: ../transactions/TransactionType.yaml
     description: List of transaction types that are enabled for this currency.
+    example: 
+      - OUTGOING
+      - INCOMING
 required:
   - currencyCode
   - minAmount

--- a/openapi/components/schemas/errors/Error400.yaml
+++ b/openapi/components/schemas/errors/Error400.yaml
@@ -1,5 +1,10 @@
 type: object
 properties:
+  status:
+    enum:
+      - 400
+    type: integer
+    description: HTTP status code
   code:
     type: string
     description: |

--- a/openapi/components/schemas/errors/Error401.yaml
+++ b/openapi/components/schemas/errors/Error401.yaml
@@ -1,5 +1,10 @@
 type: object
 properties:
+  status:
+    enum:
+      - 401
+    type: integer
+    description: HTTP status code
   code:
     type: string
     description: |

--- a/openapi/components/schemas/errors/Error403.yaml
+++ b/openapi/components/schemas/errors/Error403.yaml
@@ -1,5 +1,10 @@
 type: object
 properties:
+  status:
+    enum:
+      - 403
+    type: integer
+    description: HTTP status code
   code:
     type: string
     description: |

--- a/openapi/components/schemas/errors/Error404.yaml
+++ b/openapi/components/schemas/errors/Error404.yaml
@@ -1,5 +1,10 @@
 type: object
 properties:
+  status:
+    enum:
+      - 404
+    type: integer
+    description: HTTP status code
   code:
     type: string
     description: |

--- a/openapi/components/schemas/errors/Error409.yaml
+++ b/openapi/components/schemas/errors/Error409.yaml
@@ -1,5 +1,10 @@
 type: object
 properties:
+  status:
+    enum:
+      - 409
+    type: integer
+    description: HTTP status code
   code:
     type: string
     description: |

--- a/openapi/components/schemas/errors/Error412.yaml
+++ b/openapi/components/schemas/errors/Error412.yaml
@@ -1,5 +1,10 @@
 type: object
 properties:
+  status:
+    enum:
+      - 412
+    type: integer
+    description: HTTP status code
   code:
     type: string
     description: |

--- a/openapi/components/schemas/errors/Error424.yaml
+++ b/openapi/components/schemas/errors/Error424.yaml
@@ -1,5 +1,10 @@
 type: object
 properties:
+  status:
+    enum:
+      - 424
+    type: integer
+    description: HTTP status code
   code:
     type: string
     description: |

--- a/openapi/components/schemas/errors/Error500.yaml
+++ b/openapi/components/schemas/errors/Error500.yaml
@@ -1,5 +1,10 @@
 type: object
 properties:
+  status:
+    enum:
+      - 500
+    type: integer
+    description: HTTP status code
   code:
     type: string
     description: |

--- a/openapi/components/schemas/errors/Error501.yaml
+++ b/openapi/components/schemas/errors/Error501.yaml
@@ -1,5 +1,10 @@
 type: object
 properties:
+  status:
+    enum:
+      - 501
+    type: integer
+    description: HTTP status code
   code:
     type: string
     description: |

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -65,6 +65,19 @@ components:
 
         If the signature verification succeeds, the webhook is authentic. If
         not, it should be rejected.
+  schemas:
+    AllErrors:
+      anyOf:
+        - $ref: components/schemas/errors/Error400.yaml
+        - $ref: components/schemas/errors/Error401.yaml
+        - $ref: components/schemas/errors/Error403.yaml
+        - $ref: components/schemas/errors/Error404.yaml
+        - $ref: components/schemas/errors/Error409.yaml
+        - $ref: components/schemas/errors/Error412.yaml
+        - $ref: components/schemas/errors/Error424.yaml
+        - $ref: components/schemas/errors/Error500.yaml
+        - $ref: components/schemas/errors/Error501.yaml
+
 paths:
   /users:
     $ref: paths/users/users.yaml

--- a/openapi/paths/config/config.yaml
+++ b/openapi/paths/config/config.yaml
@@ -57,6 +57,9 @@ patch:
             - currencyCode: USD
               minAmount: 100
               maxAmount: 1000000
+              enabledTransactionTypes:
+                - OUTGOING
+                - INCOMING
               requiredCounterpartyFields:
                 - name: FULL_NAME
                   mandatory: true


### PR DESCRIPTION
### TL;DR

Added HTTP status code field to all error response schemas and created a unified Error schema.

### What changed?

- Added a `status` property to all error response schemas (400, 401, 403, 404, 409, 412, 424, 500, 501)
- The `status` property:
  - Is an integer type
  - Has an enum constraint matching the respective HTTP status code
  - Includes a description "HTTP status code"
- Created a new `Error.yaml` schema that combines all error types using `anyOf` to reference all specific error schemas

### How to test?

1. Validate the OpenAPI specification to ensure it's still valid
2. Check that API clients generated from this spec correctly include the status field
3. Verify that the unified Error schema can be used in API responses where multiple error types are possible

### Why make this change?

Including the HTTP status code in the response body provides redundancy that helps API consumers, especially when:
- HTTP status codes are lost in some proxy or middleware scenarios
- Debugging API responses where only the response body is logged
- Creating more consistent error handling in client applications

The unified Error schema simplifies API specifications by allowing endpoints to reference a single error schema rather than listing all possible error types.