### PR TITLE
feat: adding firstName to invite openapi schema

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3687,6 +3687,10 @@ components:
             - CANCELLED
           description: The status of the invitation
           example: PENDING
+        firstName:
+          type: string
+          description: The inviter's first name.  Will be displayed when the recipient clicks the invite link
+          example: Jane
         amountToSend:
           $ref: '#/components/schemas/CurrencyAmount'
           description: |-

--- a/openapi/components/schemas/invitations/UmaInvitation.yaml
+++ b/openapi/components/schemas/invitations/UmaInvitation.yaml
@@ -46,6 +46,10 @@ properties:
       - CANCELLED
     description: The status of the invitation
     example: PENDING
+  firstName:
+    type: string
+    description: The inviter's first name.  Will be displayed when the recipient clicks the invite link
+    example: Jane
   amountToSend:
     $ref: ../common/CurrencyAmount.yaml
     description: >-


### PR DESCRIPTION
### TL;DR

Added `firstName` field to the UmaInvitation schema to display the inviter's name when recipients click invite links.

### What changed?

- Added a new `firstName` property to the UmaInvitation schema in both:
  - The main OpenAPI specification file (`openapi.yaml`)
  - The component schema file (`openapi/components/schemas/invitations/UmaInvitation.yaml`)
- The field is defined as a string type with an example value of "Jane"
- Added description indicating this field will be displayed when the recipient clicks the invite link

### How to test?

1. Create a new invitation with the `firstName` field populated
2. Verify the field is properly stored in the database
3. Send an invitation link to a recipient and verify the inviter's first name appears when they click the link
4. Check API responses to confirm the field is included in the UmaInvitation object

### Why make this change?

This change improves the user experience for invitation recipients by showing them who sent the invitation. When recipients click on an invite link, they'll now see the inviter's first name, making the invitation process more personal and trustworthy.