### PR TITLE
fix: updating gradle to auto install jvm as needed and use node plugin

### DIFF
--- a/samples/kotlin/umaaas-quickstart/backend/build.gradle.kts
+++ b/samples/kotlin/umaaas-quickstart/backend/build.gradle.kts
@@ -1,31 +1,25 @@
-
 plugins {
     kotlin("jvm") version "2.1.21"
     kotlin("plugin.serialization") version "2.1.21"
     alias(libs.plugins.ktor)
+    id("com.github.node-gradle.node") version "7.1.0"
 }
 
-tasks.register<Exec>("buildFrontend") {
-    dependsOn("npmInstall")
-    workingDir = file("../frontend")
-    commandLine("npm", "run", "build")
-    group = "build"
-    description = "Build the frontend React application"
+node {
+    version.set("22.15.0")
+    download.set(true)
+    nodeProjectDir.set(file("../frontend"))
 }
 
-tasks.register<Exec>("npmInstall") {
-    workingDir = file("../frontend")
-    commandLine("npm", "install")
-    group = "build"
-    description = "Install frontend dependencies"
-    
-    inputs.file("../frontend/package.json")
-    inputs.file("../frontend/package-lock.json")
-    outputs.dir("../frontend/node_modules")
+val npmBuild by tasks.register<com.github.gradle.node.npm.task.NpmTask>("npmBuild") {
+    dependsOn(tasks.named("npmInstall"))
+    args.set(listOf("run", "build")) 
 }
+
+tasks.named<com.github.gradle.node.npm.task.NpmInstallTask>("npmInstall")
 
 tasks.named("processResources") {
-    dependsOn("buildFrontend")
+    dependsOn("npmBuild")
 }
 
 kotlin {

--- a/samples/kotlin/umaaas-quickstart/backend/gradle.properties
+++ b/samples/kotlin/umaaas-quickstart/backend/gradle.properties
@@ -1,1 +1,4 @@
 kotlin.code.style=official
+# gradle.properties
+org.gradle.java.installations.auto-download=true
+org.gradle.java.installations.auto-detect=true


### PR DESCRIPTION
### TL;DR

Replaced custom Exec tasks with the node-gradle plugin for frontend build management.

### What changed?

- Added the `com.github.node-gradle.node` plugin (version 7.1.0)
- Configured Node.js version (22.15.0) with automatic download
- Replaced custom `buildFrontend` and `npmInstall` Exec tasks with proper Node Gradle plugin tasks
- Updated the `processResources` task to depend on the new `npmBuild` task
- Added Gradle properties for Java installations auto-download and auto-detect

### How to test?

1. Run `./gradlew build` in the backend directory
2. Verify that the frontend is properly built and included in the backend resources
3. Check that the application runs correctly with the bundled frontend

### Why make this change?

The node-gradle plugin provides better integration with the Gradle build system compared to custom Exec tasks. It handles Node.js installation, dependency management, and build processes more reliably across different environments. This change improves build reproducibility and simplifies the build configuration.