### PR TITLE
feat: adding fbo path to openapi for codegen

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1403,6 +1403,55 @@ paths:
                           requiredFields:
                             - TAX_ID
                             - REGISTRATION_NUMBER
+  /fbo/confirm/{quoteId}:
+    post:
+      summary: Trigger payment from a FBO account
+      description: |
+        This endpoint should only be used for when your account is configured for FBO payments.  It triggers funding a quote from your FBO account to initiate payment.
+      operationId: fboConfirm
+      tags:
+        - Sending Payments
+      security:
+        - BasicAuth: []
+      parameters:
+        - name: quoteId
+          in: path
+          description: ID of the quote to pay from FBO
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: |
+            Payment successful.  This updates the transaction to PROCESSING.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Transaction'
+        '401':
+          description: Unauthorized
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '403':
+          description: Forbidden
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '404':
+          description: Not Found
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+        '500':
+          description: Internal Server Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /users/bulk/csv:
     post:
       summary: Upload users via CSV file

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -94,6 +94,8 @@ paths:
     $ref: paths/quotes/quotes_{quoteId}.yaml
   /quotes/{quoteId}/retry:
     $ref: paths/quotes/quotes_{quoteId}_retry.yaml
+  /fbo/confirm/{quoteId}:
+    $ref: paths/fbo/fbo_confirm_{quoteId}.yaml
   /users/bulk/csv:
     $ref: paths/users/users_bulk_csv.yaml
   /users/bulk/jobs/{jobId}:

--- a/openapi/paths/fbo/fbo_confirm_{quoteId}.yaml
+++ b/openapi/paths/fbo/fbo_confirm_{quoteId}.yaml
@@ -1,0 +1,48 @@
+post:
+  summary: Trigger payment from a FBO account
+  description: >
+    This endpoint should only be used for when your account is configured for FBO payments.  It triggers funding a quote from your FBO account to initiate payment.
+  operationId: fboConfirm
+  tags:
+    - Sending Payments
+  security:
+    - BasicAuth: []
+  parameters:
+    - name: quoteId
+      in: path
+      description: ID of the quote to pay from FBO
+      required: true
+      schema:
+        type: string
+  responses:
+    '200':
+      description: >
+        Payment successful.  This updates the transaction to PROCESSING.
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/transactions/Transaction.yaml
+    '401':
+      description: Unauthorized
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/common/Error.yaml
+    '403':
+      description: Forbidden
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/common/Error.yaml
+    '404':
+      description: Not Found
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/common/Error.yaml
+    '500':
+      description: Internal Server Error
+      content:
+        application/json:
+          schema:
+            $ref: ../../components/schemas/common/Error.yaml


### PR DESCRIPTION
### TL;DR

Added a new API endpoint for triggering payments from FBO accounts.

### What changed?

Added a new OpenAPI specification for the `POST /fbo/confirm/{quoteId}` endpoint. This endpoint allows users to trigger funding a quote from their FBO (For Benefit Of) account to initiate a payment. The endpoint requires a quote ID in the path parameter and returns the transaction details upon successful payment.

### How to test?

1. Ensure your account is configured for FBO payments
2. Create a quote using the existing quote creation endpoint
3. Call the new `POST /fbo/confirm/{quoteId}` endpoint with the quote ID
4. Verify that the response contains the transaction details with a pending status
5. Test error scenarios (401, 403, 404, 500) to ensure proper error handling

### Why make this change?

This endpoint provides a dedicated method for FBO account holders to initiate payments, which is a specific payment flow that wasn't previously supported in the API. This allows for better integration with FBO payment workflows and gives clients with FBO accounts a clear way to trigger payments from those accounts.