### PR TITLE
chore:migrate from DATE_OF_BIRTH to BIRTH_DATE

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Response:
       "mandatory": true
     },
     {
-      "name": "DATE_OF_BIRTH",
+      "name": "BIRTH_DATE",
       "mandatory": true
     }
   ],
@@ -209,7 +209,7 @@ Response:
   "feesIncluded": 100,
   "counterpartyInformation": {
     "FULL_NAME": "Jane Receiver",
-    "DATE_OF_BIRTH": "1990-01-01"
+    "BIRTH_DATE": "1990-01-01"
   },
   "paymentInstructions": {
     "reference": "UMA-Q12345-REF",
@@ -258,7 +258,7 @@ Response:
   "feesIncluded": 100,
   "counterpartyInformation": {
     "FULL_NAME": "Jane Receiver",
-    "DATE_OF_BIRTH": "1990-01-01"
+    "BIRTH_DATE": "1990-01-01"
   },
   "paymentInstructions": {
     "reference": "UMA-Q12345-REF",
@@ -398,7 +398,7 @@ Request body:
           "mandatory": true
         },
         {
-          "name": "DATE_OF_BIRTH",
+          "name": "BIRTH_DATE",
           "mandatory": true
         }
       ]
@@ -423,7 +423,7 @@ Request body:
   "platformUserId": "9f84e0c2a72c4fa",
   "userType": "INDIVIDUAL",
   "fullName": "John Sender",
-  "dateOfBirth": "1985-06-15",
+  "birthDate": "1985-06-15",
   "address": {
     "line1": "123 Pine Street",
     "line2": "Unit 501",
@@ -469,7 +469,7 @@ When someone initiates a payment to one of your users' UMA addresses, you'll rec
     "platformUserId": "9f84e0c2a72c4fa",
     "counterpartyInformation": {
       "FULL_NAME": "John Sender",
-      "DATE_OF_BIRTH": "1985-06-15"
+      "BIRTH_DATE": "1985-06-15"
     },
     "reconciliationInstructions": {
       "reference": "REF-123456789"

--- a/docusaurus-docs/docs/configuring-users.md
+++ b/docusaurus-docs/docs/configuring-users.md
@@ -88,7 +88,7 @@ Example request body for an individual user (ensure all `umaProviderRequiredUser
   "platformUserId": "9f84e0c2a72c4fa",
   "userType": "INDIVIDUAL",
   "fullName": "John Sender",
-  "dateOfBirth": "1985-06-15",
+  "birthDate": "1985-06-15",
   "address": {
     "line1": "Paseo de la Reforma 222",
     "line2": "Piso 15",
@@ -324,7 +324,7 @@ POST /users/bulk/csv
 The CSV file should follow a specific format with required and optional columns based on user type. Here's an example:
 
 ```csv
-umaAddress,platformUserId,userType,fullName,dateOfBirth,addressLine1,city,state,postalCode,country,accountType,accountNumber,bankName,platformAccountId,businessLegalName,routingNumber,accountCategory
+umaAddress,platformUserId,userType,fullName,birthDate,addressLine1,city,state,postalCode,country,accountType,accountNumber,bankName,platformAccountId,businessLegalName,routingNumber,accountCategory
 john.doe@uma.domain.com,user123,INDIVIDUAL,John Doe,1990-01-15,123 Main St,San Francisco,CA,94105,US,US_ACCOUNT,123456789,Chase Bank,chase_primary_1234,,222888888,SAVINGS
 cme@uma.domain.com,biz456,BUSINESS,,,400 Commerce Way,Austin,TX,78701,US,US_ACCOUNT,987654321,Bank of America,boa_business_5678,Acme Corp,121212121,CHECKING
 ```
@@ -393,7 +393,7 @@ Required columns for all users:
 Required columns for individual users:
 
 - fullName: Individual's full name
-- dateOfBirth: Date of birth in YYYY-MM-DD format
+- birthDate: Date of birth in YYYY-MM-DD format
 - addressLine1: Street address line 1
 - city: City
 - state: State/Province/Region
@@ -458,7 +458,7 @@ For IBAN:
 ### Example CSV
 
 ```csv
-umaAddress,platformUserId,userType,fullName,dateOfBirth,addressLine1,city,state,postalCode,country,accountType,accountNumber,routingNumber,accountCategory,bankName,platformAccountId
+umaAddress,platformUserId,userType,fullName,birthDate,addressLine1,city,state,postalCode,country,accountType,accountNumber,routingNumber,accountCategory,bankName,platformAccountId
 $john.doe@uma.domain.com,user123,INDIVIDUAL,John Doe,1990-01-15,123 Main St,San Francisco,CA,94105,US,US_ACCOUNT,123456789,987654321,CHECKING,Chase Bank,chase_primary_1234
 $acme@uma.domain.com,biz456,BUSINESS,Acme Corp,,400 Commerce Way,Austin,TX,78701,US,US_ACCOUNT,987654321,123456789,CHECKING,Bank of America,boa_business_5678,businessLegalName,Acme Corporation
 ```

--- a/docusaurus-docs/docs/platform-configuration.md
+++ b/docusaurus-docs/docs/platform-configuration.md
@@ -34,7 +34,7 @@ Response example:
           "mandatory": true
         },
         {
-          "name": "DATE_OF_BIRTH",
+          "name": "BIRTH_DATE",
           "mandatory": true
         }
       ],
@@ -76,7 +76,7 @@ Request body:
           "mandatory": true
         },
         {
-          "name": "DATE_OF_BIRTH",
+          "name": "BIRTH_DATE",
           "mandatory": true
         },
         {
@@ -107,7 +107,7 @@ Response:
           "mandatory": true
         },
         {
-          "name": "DATE_OF_BIRTH",
+          "name": "BIRTH_DATE",
           "mandatory": true
         },
         {
@@ -171,7 +171,7 @@ Available counterparty fields (to be specified with a `name` and `mandatory` fla
 | Field Name (type `UserInfoFieldName`) | Description |
 |---------------------------------------|-------------|
 | `FULL_NAME` | Full legal name of the individual or business |
-| `DATE_OF_BIRTH` | Date of birth in YYYY-MM-DD format (for individuals) |
+| `BIRTH_DATE` | Date of birth in YYYY-MM-DD format (for individuals) |
 | `NATIONALITY` | Nationality of the individual |
 | `ADDRESS` | Physical address including country, city, etc. |
 | `PHONE_NUMBER` | Contact phone number including country code |

--- a/docusaurus-docs/docs/receiving-payments.md
+++ b/docusaurus-docs/docs/receiving-payments.md
@@ -66,7 +66,7 @@ Request body:
   "platformUserId": "9f84e0c2a72c4fa",
   "userType": "INDIVIDUAL",
   "fullName": "John Receiver",
-  "dateOfBirth": "1985-06-15",
+  "birthDate": "1985-06-15",
   "address": {
     "line1": "123 Pine Street",
     "line2": "Unit 501",
@@ -118,7 +118,7 @@ When someone initiates a payment to one of your users' UMA addresses, you'll rec
     "description": "Payment for services",
     "counterpartyInformation": {
       "FULL_NAME": "Mary Sender",
-      "DATE_OF_BIRTH": "1985-06-15"
+      "BIRTH_DATE": "1985-06-15"
     },
     "reconciliationInstructions": {
       "reference": "REF-123456789"
@@ -238,7 +238,7 @@ When the payment completes, your webhook endpoint will receive another notificat
     "description": "Payment for services",
     "counterpartyInformation": {
       "FULL_NAME": "Mary Sender",
-      "DATE_OF_BIRTH": "1985-06-15"
+      "BIRTH_DATE": "1985-06-15"
     },
     "reconciliationInstructions": {
       "reference": "REF-123456789"

--- a/docusaurus-docs/docs/sandbox.md
+++ b/docusaurus-docs/docs/sandbox.md
@@ -134,7 +134,7 @@ POST /users
   "platformUserId": "test_123",
   "userType": "INDIVIDUAL",
   "fullName": "Test User",
-  "dateOfBirth": "1990-01-01",
+  "birthDate": "1990-01-01",
   "address": {
     "line1": "123 Test St",
     "city": "Testville",

--- a/docusaurus-docs/docs/sending-payments.md
+++ b/docusaurus-docs/docs/sending-payments.md
@@ -86,7 +86,7 @@ Response:
       "mandatory": true
     },
     {
-      "name": "DATE_OF_BIRTH",
+      "name": "BIRTH_DATE",
       "mandatory": true
     }
   ]
@@ -115,7 +115,7 @@ Request body:
   "description": "Invoice #1234 payment",
   "senderUserInfo": {
     "FULL_NAME": "John Sender",
-    "DATE_OF_BIRTH": "1985-06-15"
+    "BIRTH_DATE": "1985-06-15"
   }
 }
 ```
@@ -146,7 +146,7 @@ Response:
   "feesIncluded": 100,
   "counterpartyInformation": {
     "FULL_NAME": "Jane Doe",
-    "DATE_OF_BIRTH": "1992-03-25"
+    "BIRTH_DATE": "1992-03-25"
   },
   "paymentInstructions": {
     "reference": "UMA-Q12345-REF",
@@ -197,7 +197,7 @@ Response:
   "feesIncluded": 100,
   "counterpartyInformation": {
     "FULL_NAME": "Jane Doe",
-    "DATE_OF_BIRTH": "1992-03-25"
+    "BIRTH_DATE": "1992-03-25"
   },
   "paymentInstructions": {
     "reference": "UMA-Q12345-REF",

--- a/docusaurus-docs/src/pages/receiving-payments-jit.md
+++ b/docusaurus-docs/src/pages/receiving-payments-jit.md
@@ -67,7 +67,7 @@ Request body:
       "mandatory": true
     },
     {
-      "name": "DATE_OF_BIRTH",
+      "name": "BIRTH_DATE",
       "mandatory": true
     }
   ]
@@ -121,7 +121,7 @@ When someone initiates a payment to one of your users' UMA addresses, you'll rec
     "description": "Payment for services",
     "counterpartyInformation": {
       "fullName": "John Sender",
-      "dateOfBirth": "1985-06-15"
+      "birthDate": "1985-06-15"
     },
     "requiredPayeeInformationFields": [
       {
@@ -129,7 +129,7 @@ When someone initiates a payment to one of your users' UMA addresses, you'll rec
         "mandatory": true
       },
       {
-        "name": "DATE_OF_BIRTH",
+        "name": "BIRTH_DATE",
         "mandatory": true
       }
     ]
@@ -146,7 +146,7 @@ To approve the payment, respond with a 200 OK status and include the payee infor
 {
   "payeeInformation": {
     "fullName": "John Sender",
-    "dateOfBirth": "1985-06-15"
+    "birthDate": "1985-06-15"
   },
   "bankAccountInfo": {
     "accountType": "CLABE",

--- a/docusaurus-docs/src/pages/sending-payments-jit.md
+++ b/docusaurus-docs/src/pages/sending-payments-jit.md
@@ -91,7 +91,7 @@ Response:
       "mandatory": true
     },
     {
-      "name": "DATE_OF_BIRTH",
+      "name": "BIRTH_DATE",
       "mandatory": true
     }
   ]
@@ -119,7 +119,7 @@ Request body:
   "description": "Invoice #1234 payment",
   "payerInformation": {
     "FULL_NAME": "John Doe",
-    "DATE_OF_BIRTH": "1990-01-01"
+    "BIRTH_DATE": "1990-01-01"
   }
 }
 ```
@@ -148,7 +148,7 @@ Response:
   "feesIncluded": 100,
   "counterpartyInformation": {
     "FULL_NAME": "Jane Doe",
-    "DATE_OF_BIRTH": "1992-03-25"
+    "BIRTH_DATE": "1992-03-25"
   },
   "paymentInstructions": {
     "reference": "UMA-Q12345-REF",
@@ -197,7 +197,7 @@ Response:
   "feesIncluded": 100,
   "counterpartyInformation": {
     "FULL_NAME": "Jane Doe",
-    "DATE_OF_BIRTH": "1992-03-25"
+    "BIRTH_DATE": "1992-03-25"
   },
   "paymentInstructions": {
     "reference": "UMA-Q12345-REF",

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -64,7 +64,7 @@ paths:
                   platformUserId: 7b3c5a89d2f1e0
                   userType: INDIVIDUAL
                   fullName: Jane Doe
-                  dateOfBirth: '1992-03-25'
+                  birthDate: '1992-03-25'
                   address:
                     line1: 123 Pine Street
                     line2: Unit 501
@@ -321,7 +321,7 @@ paths:
                     fullName:
                       type: string
                       description: Individual's full name
-                    dateOfBirth:
+                    birthDate:
                       type: string
                       format: date
                       description: Date of birth in ISO 8601 format (YYYY-MM-DD)
@@ -360,7 +360,7 @@ paths:
                 value:
                   userType: INDIVIDUAL
                   fullName: John Smith
-                  dateOfBirth: '1985-06-15'
+                  birthDate: '1985-06-15'
                   address:
                     line1: 456 Market St
                     city: San Francisco
@@ -735,7 +735,7 @@ paths:
                       mandatory: true
                     - name: NATIONALITY
                       mandatory: true
-                    - name: DATE_OF_BIRTH
+                    - name: BIRTH_DATE
                       mandatory: true
       responses:
         '200':
@@ -1469,7 +1469,7 @@ paths:
 
         Required columns for individual users:
         - fullName: Individual's full name
-        - dateOfBirth: Date of birth in YYYY-MM-DD format
+        - birthDate: Date of birth in YYYY-MM-DD format
         - addressLine1: Street address line 1
         - city: City
         - state: State/Province/Region
@@ -1523,7 +1523,7 @@ paths:
 
         ### Example CSV
         ```csv
-        umaAddress,platformUserId,userType,fullName,dateOfBirth,addressLine1,city,state,postalCode,country,accountType,accountNumber,bankName,platformAccountId,businessLegalName,routingNumber,accountCategory
+        umaAddress,platformUserId,userType,fullName,birthDate,addressLine1,city,state,postalCode,country,accountType,accountNumber,bankName,platformAccountId,businessLegalName,routingNumber,accountCategory
         john.doe@uma.domain.com,user123,INDIVIDUAL,John Doe,1990-01-15,123 Main St,San Francisco,CA,94105,US,US_ACCOUNT,123456789,Chase Bank,chase_primary_1234,,222888888,SAVINGS
         acme@uma.domain.com,biz456,BUSINESS,,,400 Commerce Way,Austin,TX,78701,US,US_ACCOUNT,987654321,Bank of America,boa_business_5678,Acme Corp,121212121,CHECKING
         ```
@@ -2120,7 +2120,7 @@ webhooks:
                       reference: REF-123456789
                     counterpartyInformation:
                       FULL_NAME: John Sender
-                      DATE_OF_BIRTH: '1985-06-15'
+                      BIRTH_DATE: '1985-06-15'
                       NATIONALITY: US
                   requestedReceiverUserInfoFields:
                     - name: NATIONALITY
@@ -2586,7 +2586,7 @@ components:
               type: string
               description: Individual's full name
               example: John Michael Doe
-            dateOfBirth:
+            birthDate:
               type: string
               format: date
               description: Date of birth in ISO 8601 format (YYYY-MM-DD)
@@ -2982,7 +2982,7 @@ components:
       type: string
       enum:
         - FULL_NAME
-        - DATE_OF_BIRTH
+        - BIRTH_DATE
         - NATIONALITY
         - PHONE_NUMBER
         - EMAIL
@@ -3041,7 +3041,7 @@ components:
           example:
             - name: FULL_NAME
               mandatory: true
-            - name: DATE_OF_BIRTH
+            - name: BIRTH_DATE
               mandatory: true
             - name: NATIONALITY
               mandatory: true
@@ -3053,7 +3053,7 @@ components:
           readOnly: true
           example:
             - NATIONALITY
-            - DATE_OF_BIRTH
+            - BIRTH_DATE
         umaProviderRequiredCounterpartyUserFields:
           type: array
           items:
@@ -3183,7 +3183,7 @@ components:
           additionalProperties: true
           example:
             FULL_NAME: John Sender
-            DATE_OF_BIRTH: '1985-06-15'
+            BIRTH_DATE: '1985-06-15'
             NATIONALITY: DE
       discriminator:
         propertyName: type
@@ -3599,7 +3599,7 @@ components:
           additionalProperties: true
           example:
             FULL_NAME: Jane Receiver
-            DATE_OF_BIRTH: '1990-01-01'
+            BIRTH_DATE: '1990-01-01'
             NATIONALITY: FR
         paymentInstructions:
           $ref: '#/components/schemas/PaymentInstructions'

--- a/openapi/components/schemas/config/PlatformCurrencyConfig.yaml
+++ b/openapi/components/schemas/config/PlatformCurrencyConfig.yaml
@@ -28,7 +28,7 @@ properties:
     example:
       - name: FULL_NAME
         mandatory: true
-      - name: DATE_OF_BIRTH
+      - name: BIRTH_DATE
         mandatory: true
       - name: NATIONALITY
         mandatory: true
@@ -44,7 +44,7 @@ properties:
     readOnly: true
     example:
       - NATIONALITY
-      - DATE_OF_BIRTH
+      - BIRTH_DATE
   umaProviderRequiredCounterpartyUserFields:
     type: array
     items:

--- a/openapi/components/schemas/quotes/Quote.yaml
+++ b/openapi/components/schemas/quotes/Quote.yaml
@@ -60,7 +60,7 @@ properties:
     additionalProperties: true
     example:
       FULL_NAME: Jane Receiver
-      DATE_OF_BIRTH: '1990-01-01'
+      BIRTH_DATE: '1990-01-01'
       NATIONALITY: FR
   paymentInstructions:
     $ref: ../common/PaymentInstructions.yaml

--- a/openapi/components/schemas/transactions/Transaction.yaml
+++ b/openapi/components/schemas/transactions/Transaction.yaml
@@ -59,7 +59,7 @@ properties:
     additionalProperties: true
     example:
       FULL_NAME: John Sender
-      DATE_OF_BIRTH: '1985-06-15'
+      BIRTH_DATE: '1985-06-15'
       NATIONALITY: DE
 discriminator:
   propertyName: type

--- a/openapi/components/schemas/users/IndividualUser.yaml
+++ b/openapi/components/schemas/users/IndividualUser.yaml
@@ -8,7 +8,7 @@ allOf:
         type: string
         description: Individual's full name
         example: John Michael Doe
-      dateOfBirth:
+      birthDate:
         type: string
         format: date
         description: Date of birth in ISO 8601 format (YYYY-MM-DD)

--- a/openapi/components/schemas/users/UserInfoFieldName.yaml
+++ b/openapi/components/schemas/users/UserInfoFieldName.yaml
@@ -1,7 +1,7 @@
 type: string
 enum:
   - FULL_NAME
-  - DATE_OF_BIRTH
+  - BIRTH_DATE
   - NATIONALITY
   - PHONE_NUMBER
   - EMAIL

--- a/openapi/paths/config/config.yaml
+++ b/openapi/paths/config/config.yaml
@@ -56,7 +56,7 @@ patch:
                   mandatory: true
                 - name: NATIONALITY
                   mandatory: true
-                - name: DATE_OF_BIRTH
+                - name: BIRTH_DATE
                   mandatory: true
   responses:
     '200':

--- a/openapi/paths/users/users.yaml
+++ b/openapi/paths/users/users.yaml
@@ -29,7 +29,7 @@ post:
               platformUserId: 7b3c5a89d2f1e0
               userType: INDIVIDUAL
               fullName: Jane Doe
-              dateOfBirth: '1992-03-25'
+              birthDate: '1992-03-25'
               address:
                 line1: 123 Pine Street
                 line2: Unit 501

--- a/openapi/paths/users/users_bulk_csv.yaml
+++ b/openapi/paths/users/users_bulk_csv.yaml
@@ -25,7 +25,7 @@ post:
 
     - fullName: Individual's full name
 
-    - dateOfBirth: Date of birth in YYYY-MM-DD format
+    - birthDate: Date of birth in YYYY-MM-DD format
 
     - addressLine1: Street address line 1
 
@@ -123,7 +123,7 @@ post:
 
     ```csv
 
-    umaAddress,platformUserId,userType,fullName,dateOfBirth,addressLine1,city,state,postalCode,country,accountType,accountNumber,bankName,platformAccountId,businessLegalName,routingNumber,accountCategory
+    umaAddress,platformUserId,userType,fullName,birthDate,addressLine1,city,state,postalCode,country,accountType,accountNumber,bankName,platformAccountId,businessLegalName,routingNumber,accountCategory
 
     john.doe@uma.domain.com,user123,INDIVIDUAL,John Doe,1990-01-15,123 Main
     St,San Francisco,CA,94105,US,US_ACCOUNT,123456789,Chase

--- a/openapi/paths/users/users_{userId}.yaml
+++ b/openapi/paths/users/users_{userId}.yaml
@@ -62,7 +62,7 @@ patch:
                 fullName:
                   type: string
                   description: Individual's full name
-                dateOfBirth:
+                birthDate:
                   type: string
                   format: date
                   description: Date of birth in ISO 8601 format (YYYY-MM-DD)
@@ -101,7 +101,7 @@ patch:
             value:
               userType: INDIVIDUAL
               fullName: John Smith
-              dateOfBirth: '1985-06-15'
+              birthDate: '1985-06-15'
               address:
                 line1: 456 Market St
                 city: San Francisco

--- a/openapi/webhooks/incoming-payment.yaml
+++ b/openapi/webhooks/incoming-payment.yaml
@@ -89,7 +89,7 @@ post:
                   reference: REF-123456789
                 counterpartyInformation:
                   FULL_NAME: John Sender
-                  DATE_OF_BIRTH: '1985-06-15'
+                  BIRTH_DATE: '1985-06-15'
                   NATIONALITY: US
               requestedReceiverUserInfoFields:
                 - name: NATIONALITY


### PR DESCRIPTION
### TL;DR

Renamed `DATE_OF_BIRTH` to `BIRTH_DATE` across all API references and documentation.

### What changed?

- Changed all instances of `DATE_OF_BIRTH` to `BIRTH_DATE` in the UserInfoFieldName enum
- Updated corresponding field in user objects from `dateOfBirth` to `birthDate` in camelCase format
- Modified all examples, request/response samples, and CSV templates to use the new field name
- Updated all documentation references to reflect this naming change

### How to test?

1. Verify that all API endpoints accept `BIRTH_DATE` instead of `DATE_OF_BIRTH` in requests
2. Confirm that user creation and update endpoints accept `birthDate` instead of `dateOfBirth`
3. Test CSV bulk uploads with the new column name format
4. Check that webhook payloads contain the updated field name

### Why make this change?

This change standardizes the naming convention for date of birth fields across the API. The new name `BIRTH_DATE` is more consistent with other field naming patterns and provides better clarity. This change ensures a more intuitive developer experience by using consistent terminology throughout the platform.