### PR TITLE
feat: adding required fields for errors

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3128,6 +3128,10 @@ components:
                   example: EIN-987654321
     Error400:
       type: object
+      required:
+        - message
+        - status
+        - code
       properties:
         status:
           enum:
@@ -3202,6 +3206,10 @@ components:
           description: Additional error details
     Error401:
       type: object
+      required:
+        - message
+        - status
+        - code
       properties:
         status:
           enum:
@@ -3226,6 +3234,10 @@ components:
           description: Additional error details
     Error500:
       type: object
+      required:
+        - message
+        - status
+        - code
       properties:
         status:
           enum:
@@ -3252,6 +3264,10 @@ components:
           description: Additional error details
     Error409:
       type: object
+      required:
+        - message
+        - status
+        - code
       properties:
         status:
           enum:
@@ -3276,6 +3292,10 @@ components:
           description: Additional error details
     Error501:
       type: object
+      required:
+        - message
+        - status
+        - code
       properties:
         status:
           enum:
@@ -3300,6 +3320,10 @@ components:
           description: Additional error details
     Error404:
       type: object
+      required:
+        - message
+        - status
+        - code
       properties:
         status:
           enum:
@@ -3959,6 +3983,10 @@ components:
           example: 1000000
     Error412:
       type: object
+      required:
+        - message
+        - status
+        - code
       properties:
         status:
           enum:
@@ -3981,6 +4009,10 @@ components:
           description: Additional error details
     Error424:
       type: object
+      required:
+        - message
+        - status
+        - code
       properties:
         status:
           enum:
@@ -4217,6 +4249,10 @@ components:
             This field is useful for "send-by-link" style user flows where an inviter can send a payment simply by sharing a link without knowing the receiver's UMA address. Note that these sends can only be sender-locked, meaning that the sender will not know ahead of time how much the receiver will receive in the receiving currency.
     Error403:
       type: object
+      required:
+        - message
+        - status
+        - code
       properties:
         status:
           enum:

--- a/openapi/components/schemas/errors/Error400.yaml
+++ b/openapi/components/schemas/errors/Error400.yaml
@@ -1,4 +1,8 @@
 type: object
+required: 
+  - message
+  - status
+  - code
 properties:
   status:
     enum:

--- a/openapi/components/schemas/errors/Error401.yaml
+++ b/openapi/components/schemas/errors/Error401.yaml
@@ -1,4 +1,8 @@
 type: object
+required: 
+  - message
+  - status
+  - code
 properties:
   status:
     enum:

--- a/openapi/components/schemas/errors/Error403.yaml
+++ b/openapi/components/schemas/errors/Error403.yaml
@@ -1,4 +1,8 @@
 type: object
+required: 
+  - message
+  - status
+  - code
 properties:
   status:
     enum:

--- a/openapi/components/schemas/errors/Error404.yaml
+++ b/openapi/components/schemas/errors/Error404.yaml
@@ -1,4 +1,8 @@
 type: object
+required: 
+  - message
+  - status
+  - code
 properties:
   status:
     enum:

--- a/openapi/components/schemas/errors/Error409.yaml
+++ b/openapi/components/schemas/errors/Error409.yaml
@@ -1,4 +1,8 @@
 type: object
+required: 
+  - message
+  - status
+  - code
 properties:
   status:
     enum:

--- a/openapi/components/schemas/errors/Error412.yaml
+++ b/openapi/components/schemas/errors/Error412.yaml
@@ -1,4 +1,8 @@
 type: object
+required: 
+  - message
+  - status
+  - code
 properties:
   status:
     enum:

--- a/openapi/components/schemas/errors/Error424.yaml
+++ b/openapi/components/schemas/errors/Error424.yaml
@@ -1,4 +1,8 @@
 type: object
+required: 
+  - message
+  - status
+  - code
 properties:
   status:
     enum:

--- a/openapi/components/schemas/errors/Error500.yaml
+++ b/openapi/components/schemas/errors/Error500.yaml
@@ -1,4 +1,8 @@
 type: object
+required: 
+  - message
+  - status
+  - code
 properties:
   status:
     enum:

--- a/openapi/components/schemas/errors/Error501.yaml
+++ b/openapi/components/schemas/errors/Error501.yaml
@@ -1,4 +1,8 @@
 type: object
+required: 
+  - message
+  - status
+  - code
 properties:
   status:
     enum:


### PR DESCRIPTION
### TL;DR

Added required fields to all error schema definitions.

### What changed?

Added the `required` property to all error schema definitions (Error400, Error401, Error403, Error404, Error409, Error412, Error424, Error500, Error501) specifying that `message`, `status`, and `code` fields are mandatory in error responses.

