### PR TITLE
fix: defaulting to showing all openapi endpoints

### DIFF
--- a/mintlify/docs.json
+++ b/mintlify/docs.json
@@ -56,7 +56,6 @@
       },
       {
         "tab": "API reference",
-        "openapi": "openapi.yaml",
         "groups": [
           {
             "group": "Using the API",
@@ -66,11 +65,7 @@
           },
           {
             "group": "API documentation",
-            
-            "pages":[
-              "POST /users",
-              "GET /users"
-            ]
+            "openapi": "openapi.yaml"
           }
         ]
       },


### PR DESCRIPTION
### TL;DR

Moved the OpenAPI specification reference from the tab level to the "API documentation" group level in the Mintlify docs configuration.
