### PR TITLE
Make umaAddress optional in create user endpoint

### DIFF
--- a/openapi/components/schemas/users/User.yaml
+++ b/openapi/components/schemas/users/User.yaml
@@ -1,6 +1,5 @@
 type: object
 required:
-  - umaAddress
   - platformUserId
   - userType
 properties:


### PR DESCRIPTION
This allows users to be created without an UMA address, which will be auto-generated by the system. Needed for SoFi's FX discovery flow where users don't provide an UMA address upfront.

https://claude.ai/code/session_01S9UjiuUhTGRtySPbk9Nyon