### PR TITLE
Add company legal name field to umaaas api

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -3460,6 +3460,7 @@ components:
         - ULTIMATE_INSTITUTION_COUNTRY
         - IDENTIFIER
         - BUSINESS_TYPE
+        - COMPANY_LEGAL_NAME
       description: Name of a type of field containing info about a platform's user or counterparty user.
       example: FULL_NAME
     CounterpartyFieldDefinition:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3460,6 +3460,7 @@ components:
         - ULTIMATE_INSTITUTION_COUNTRY
         - IDENTIFIER
         - BUSINESS_TYPE
+        - COMPANY_LEGAL_NAME
       description: Name of a type of field containing info about a platform's user or counterparty user.
       example: FULL_NAME
     CounterpartyFieldDefinition:


### PR DESCRIPTION
Thunes requires legalName from the sender when it's a business sender 
```
{
    "code": "UNRECOGNIZED_MANDATORY_COUNTERPARTY_DATA_KEY",
    "reason": "Unrecognized counterparty field name companyLegalName"
}
```

this exists as UmaCounterpartyDataField.COMPANY_LEGAL_NAME, but how no corresponding CustomerInfoFieldName