### PR TITLE
Add COMPANY_LEGAL_NAME to UserInfoFieldName enum

### DIFF
--- a/mintlify/openapi.yaml
+++ b/mintlify/openapi.yaml
@@ -3460,6 +3460,7 @@ components:
         - ULTIMATE_INSTITUTION_COUNTRY
         - IDENTIFIER
         - BUSINESS_TYPE
+        - COMPANY_LEGAL_NAME
       description: Name of a type of field containing info about a platform's user or counterparty user.
       example: FULL_NAME
     CounterpartyFieldDefinition:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -3460,6 +3460,7 @@ components:
         - ULTIMATE_INSTITUTION_COUNTRY
         - IDENTIFIER
         - BUSINESS_TYPE
+        - COMPANY_LEGAL_NAME
       description: Name of a type of field containing info about a platform's user or counterparty user.
       example: FULL_NAME
     CounterpartyFieldDefinition:

--- a/openapi/components/schemas/users/UserInfoFieldName.yaml
+++ b/openapi/components/schemas/users/UserInfoFieldName.yaml
@@ -17,6 +17,7 @@ enum:
   - ULTIMATE_INSTITUTION_COUNTRY
   - IDENTIFIER
   - BUSINESS_TYPE
+  - COMPANY_LEGAL_NAME
 description: >-
   Name of a type of field containing info about a platform's user or
   counterparty user.


### PR DESCRIPTION
## What

Adds `COMPANY_LEGAL_NAME` to the `UserInfoFieldName` enum (last entry, after `BUSINESS_TYPE`).

Regenerated the bundled `openapi.yaml` and `mintlify/openapi.yaml` via `npm run build:openapi`. No version bump and no `generated/` regen, matching the convention for prior single-value additions (#248 "Add new business type field", #232 "Add identifier to userinfofieldname").

## Why

`companyLegalName` is a valid UMA counterparty data field used for B2B payment support (Tazapay). It already exists in the UMA protocol enum (`UmaCounterpartyDataField.COMPANY_LEGAL_NAME = "companyLegalName"`) and in the Grid API's `CustomerInfoFieldName` enum, but was never added here.

As a result, when a receiver VASP marks `companyLegalName` as a *mandatory* counterparty field, sparkcore's UMAaaS VASP (`convert_requested_counterparty_data`) cannot map it to a `UserInfoFieldName` and raises a 501 `UNRECOGNIZED_MANDATORY_COUNTERPARTY_DATA_KEY`, which **pages on-call** on `gen_create_quote` / `/grid/rc/quotes`. `COMPANY_LEGAL_NAME` is currently the only field the Grid/UMA enums recognize that UMAaaS does not.

A matching fix was applied to the *vendored* copy of this spec in `lightsparkdev/webdev` (`umaaas-api/`), but that copy is regenerated from this repo via `update_schema.sh`. Without this upstream change, the next regen silently reverts the fix and the alert returns.

## Related

- sparkcore-side change: _<link to be added>_

🤖 Generated with [Claude Code](https://claude.com/claude-code)